### PR TITLE
Fix bottom navbar on devices with narrow screen width

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -49,5 +49,21 @@ jQuery(function($) {
     $(collapsed).css('height', '100%');
   });
 
+});
 
+var unlockNavbarIfNecessary = function() {
+    var iphone6PlusLandscapeWidth = 736;
+    var bottomNavbar = $('div.bottom');
+    if ($(window).width() > iphone6PlusLandscapeWidth) {
+        bottomNavbar.addClass('navbar-fixed-bottom');
+    } else {
+        bottomNavbar.removeClass('navbar-fixed-bottom')
+    }
+};
+
+$(document).ready(function () {
+    unlockNavbarIfNecessary();
+    $(window).resize(function () {
+        unlockNavbarIfNecessary();
+    });
 });

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -15,17 +15,4 @@
       <% end %>
     </div>
   </div>
-  <script>
-      var unlockNavbarIfNecessary = function() {
-          if ($(window).width() >= 500) {
-              $('div.bottom').addClass('navbar-fixed-bottom');
-          } else {
-              $('div.bottom').removeClass('navbar-fixed-bottom')
-          }
-      };
-      unlockNavbarIfNecessary();
-      $(window).resize(function() {
-          unlockNavbarIfNecessary();
-      });
-  </script>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,7 +1,7 @@
 <div class="content-wrapper">
   <%= render partial: 'as_html', locals: {items: @items} %>
 
-  <div class='bottom navbar-fixed-bottom box-shadow-top'>
+  <div class='bottom box-shadow-top'>
     <div class='navbar-inner'>
       <%= link_to 'Presentation', presentation_standup_items_path(@standup), class: 'btn btn-success navbar-btn' %>
       <%= form_tag "/standups/#{@standup.id}/posts", method: 'post', class: 'navbar-form pull-right' do %>
@@ -15,4 +15,17 @@
       <% end %>
     </div>
   </div>
+  <script>
+      var unlockNavbarIfNecessary = function() {
+          if ($(window).width() >= 500) {
+              $('div.bottom').addClass('navbar-fixed-bottom');
+          } else {
+              $('div.bottom').removeClass('navbar-fixed-bottom')
+          }
+      };
+      unlockNavbarIfNecessary();
+      $(window).resize(function() {
+          unlockNavbarIfNecessary();
+      });
+  </script>
 </div>

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -216,6 +216,7 @@ describe "items", js: true do
       it "locks to the bottom of the screen but unlocks whenever the width goes below 737px" do
         page.driver.resize_window 737, 2000
 
+        login
         visit '/'
         click_link(standup.title)
 
@@ -231,6 +232,7 @@ describe "items", js: true do
       it "is unlocked from the bottom of the screen but locks whenever the width goes above 737px" do
         page.driver.resize_window 736, 2000
 
+        login
         visit '/'
         click_link(standup.title)
 

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -210,6 +210,21 @@ describe "items", js: true do
       page.should have_content "Woohoo"
     end
   end
+
+  context "the bottom navbar" do
+    it "dynamically locks to the bottom of the screen when the screen width is greater than 500px, and unlocks when it is below 500px" do
+      page.driver.resize_window 500, 2000
+
+      visit '/'
+      click_link(standup.title)
+
+      page.find('div.content-wrapper').should have_css('.navbar-fixed-bottom')
+      page.driver.resize_window 499, 2000
+      page.find('div.content-wrapper').should_not have_css('.navbar-fixed-bottom')
+      page.driver.resize_window 500, 2000
+      page.find('div.content-wrapper').should have_css('.navbar-fixed-bottom')
+    end
+  end
 end
 
 def fill_date_selector_with(date)

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -211,18 +211,35 @@ describe "items", js: true do
     end
   end
 
-  context "the bottom navbar" do
-    it "dynamically locks to the bottom of the screen when the screen width is greater than 500px, and unlocks when it is below 500px" do
-      page.driver.resize_window 500, 2000
+  describe "the bottom navbar" do
+    context "when the screen width starts at or above 737px" do
+      it "locks to the bottom of the screen but unlocks whenever the width goes below 737px" do
+        page.driver.resize_window 737, 2000
 
-      visit '/'
-      click_link(standup.title)
+        visit '/'
+        click_link(standup.title)
 
-      page.find('div.content-wrapper').should have_css('.navbar-fixed-bottom')
-      page.driver.resize_window 499, 2000
-      page.find('div.content-wrapper').should_not have_css('.navbar-fixed-bottom')
-      page.driver.resize_window 500, 2000
-      page.find('div.content-wrapper').should have_css('.navbar-fixed-bottom')
+        page.find('div.content-wrapper').should have_css('.navbar-fixed-bottom')
+        page.driver.resize_window 736, 2000
+        page.find('div.content-wrapper').should_not have_css('.navbar-fixed-bottom')
+        page.driver.resize_window 737, 2000
+        page.find('div.content-wrapper').should have_css('.navbar-fixed-bottom')
+      end
+    end
+
+    context "when the screen width starts below 737px" do
+      it "is unlocked from the bottom of the screen but locks whenever the width goes above 737px" do
+        page.driver.resize_window 736, 2000
+
+        visit '/'
+        click_link(standup.title)
+
+        page.find('div.content-wrapper').should_not have_css('.navbar-fixed-bottom')
+        page.driver.resize_window 737, 2000
+        page.find('div.content-wrapper').should have_css('.navbar-fixed-bottom')
+        page.driver.resize_window 736, 2000
+        page.find('div.content-wrapper').should_not have_css('.navbar-fixed-bottom')
+      end
     end
   end
 end

--- a/spec/features/publishing_spec.rb
+++ b/spec/features/publishing_spec.rb
@@ -72,7 +72,6 @@ describe "publishing", js: true do
     page.should have_css('a', text: 'Post Blog Entry')
   end
 
-
   it "shows the URL the post was published to" , js: true do
     WordpressService.any_instance.should_receive(:send!).and_return("best-post-eva")
     click_link(standup.title)


### PR DESCRIPTION
In response to https://www.pivotaltracker.com/story/show/102424602:

This pull request enables the footer to be dynamically locked or unlocked to the bottom of the screen, depending on the width of the window.  If the window width is equal to or narrower than the width of a landscape-mode iPhone 6 Plus, the navbar is unlocked from the bottom of the screen. Otherwise, the footer affixes to the bottom of the screen. This feature is dynamic, allowing the footer to lock and unlock as the screen is resized.

Tests are currently failing on CI because it appears some environment variables are not available to branches, particularly the IP_WHITELIST variable.