### PR TITLE
Remove footer dropshadow

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -50,20 +50,3 @@ jQuery(function($) {
   });
 
 });
-
-var unlockNavbarIfNecessary = function() {
-    var iphone6PlusLandscapeWidth = 736;
-    var bottomNavbar = $('div.bottom');
-    if ($(window).width() > iphone6PlusLandscapeWidth) {
-        bottomNavbar.addClass('navbar-fixed-bottom');
-    } else {
-        bottomNavbar.removeClass('navbar-fixed-bottom')
-    }
-};
-
-$(document).ready(function () {
-    unlockNavbarIfNecessary();
-    $(window).resize(function () {
-        unlockNavbarIfNecessary();
-    });
-});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -42,7 +42,16 @@ a:hover {
 
 .content-wrapper {
   padding: 0px 15px;
-  margin: 50px 0px 0px 0px;
+}
+
+.site-container {
+  display: flex;
+  min-height: calc(100vh - 70px);
+  flex-direction: column;
+}
+
+.site-body {
+  flex: 1;
 }
 
 .standup {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -74,8 +74,8 @@ a:hover {
   color: #666;
 }
 
-.box-shadow-top{
-  box-shadow: 0 -1px 10px rgba(0,0,0,0.1)
+.border-top {
+  border-top: 1px solid #ccc;
 }
 
 .block {

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,7 +3,7 @@
     <%= render partial: 'as_html', locals: {items: @items} %>
   </div>
 
-  <div class='bottom box-shadow-top'>
+  <div class='bottom border-top'>
     <div class='navbar-inner'>
       <%= link_to 'Presentation', presentation_standup_items_path(@standup), class: 'btn btn-success navbar-btn' %>
       <%= form_tag "/standups/#{@standup.id}/posts", method: 'post', class: 'navbar-form pull-right' do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,17 +1,19 @@
-<div class="content-wrapper">
-  <%= render partial: 'as_html', locals: {items: @items} %>
+<div class="content-wrapper site-container">
+  <div class="site-body">
+    <%= render partial: 'as_html', locals: {items: @items} %>
+  </div>
 
   <div class='bottom box-shadow-top'>
     <div class='navbar-inner'>
       <%= link_to 'Presentation', presentation_standup_items_path(@standup), class: 'btn btn-success navbar-btn' %>
       <%= form_tag "/standups/#{@standup.id}/posts", method: 'post', class: 'navbar-form pull-right' do %>
-        <%= text_field_tag 'post[from]', nil, placeholder: 'Blogger Name(s)' %>
-        <%= text_field_tag 'post[title]', nil, placeholder: 'Post Title (eg: Best Standup Ever)', class: 'wide-input' %>
-        <%= submit_tag 'Create Post',
-          data: {confirm: 'This will clear the board and create a new one for tomorrow, you can always get back to this post under the "Posts" menu in the header. Continue?'},
-          id: 'create-post',
-          class: 'btn btn-warning'
-        %>
+          <%= text_field_tag 'post[from]', nil, placeholder: 'Blogger Name(s)' %>
+          <%= text_field_tag 'post[title]', nil, placeholder: 'Post Title (eg: Best Standup Ever)', class: 'wide-input' %>
+          <%= submit_tag 'Create Post',
+                         data: {confirm: 'This will clear the board and create a new one for tomorrow, you can always get back to this post under the "Posts" menu in the header. Continue?'},
+                         id: 'create-post',
+                         class: 'btn btn-warning'
+          %>
       <% end %>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,13 +9,11 @@
   <link rel="apple-touch-icon-precomposed" href="<%= asset_path 'whiteboard-icon.png' %>">
 </head>
 <body>
-
 <%= render partial: '/partials/nav' %>
 <% if flash %>
-  <%= render partial: '/partials/flash' %>
+    <%= render partial: '/partials/flash' %>
 <% end %>
 
 <%= yield %>
-
 </body>
 </html>


### PR DESCRIPTION
The standup items page bottom navbar made use of a dropshadow that did not look great on a mobile device when it stacked. This PR replaces that dropshadow with a single grey border top to match the border bottoms of all the other items on that page. 