### PR TITLE
Prefer Time.zone.local to Time.local so that tests can pass down under!

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Development
 ===========
 Whiteboard is a Rails 4 app. It uses rspec with capybara for request specs.  Please add tests if you are adding code.
 
+Whiteboard feature tests are incompatible with Qt 5.5, ensure you have a lower version installed before running `bundle`
+
 Whiteboard [is on Pivotal Tracker](https://www.pivotaltracker.com/projects/560741).
 
 The following environment variables are necessary for posting to a Wordpress blog.

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,13 +13,14 @@ class ItemsController < ApplicationController
   def new
     @standup = Standup.find_by_id(params[:standup_id])
     options = (params[:item] || {}).merge({post_id: params[:post_id], author: session[:username]})
+    options.reverse_merge!(date: Time.zone.today)
     @item = @standup.items.build(options)
     render_custom_item_template @item
   end
 
   def index
     @standup = Standup.find_by_id(params[:standup_id])
-    events = Item.events_on_or_after(Date.today, @standup)
+    events = Item.events_on_or_after(Time.zone.today, @standup)
     @items = @standup.items.orphans.merge(events)
   end
 
@@ -45,7 +46,7 @@ class ItemsController < ApplicationController
   end
 
   def presentation
-    events = Item.events_on_or_after(Date.today, @standup)
+    events = Item.events_on_or_after(Time.zone.today, @standup)
     @items = @standup.items.orphans.merge(events)
     render layout: 'deck'
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -66,6 +66,7 @@ class ItemsController < ApplicationController
     elsif params.fetch(:item, {})[:standup_id].present?
       standup = Standup.find_by(id: params[:item][:standup_id])
     else
+
       standup = Item.find_by(id: params[:id]).standup
     end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,8 @@
 class PostsController < ApplicationController
   before_filter :load_post, except: [:create, :index, :archived]
   before_filter :load_standup
+  around_filter :standup_timezone
+
 
   def create
     @standup = Standup.find_by_id(params[:standup_id])
@@ -84,7 +86,7 @@ class PostsController < ApplicationController
 
   def load_standup
     if params[:standup_id].present?
-      @standup = Standup.find(params[:standup_id])
+      @standup = Standup.find_by(id: params[:standup_id])
     else
       @standup = Post.find(params[:id]).standup
     end
@@ -96,5 +98,11 @@ class PostsController < ApplicationController
                        formats: [:text],
                        layout: false,
                        locals: {items: items, include_authors: false}))
+  end
+
+
+  def standup_timezone(&block)
+    return yield unless @standup
+    Time.use_zone(@standup.time_zone_name, &block)
   end
 end

--- a/app/controllers/standups_controller.rb
+++ b/app/controllers/standups_controller.rb
@@ -1,4 +1,7 @@
 class StandupsController < ApplicationController
+  before_filter :load_standup, only: [:edit, :show, :update, :destroy]
+  around_filter :standup_timezone, only: [:edit, :show, :update, :destroy]
+
   def create
     @standup = Standup.create(params[:standup])
 
@@ -18,12 +21,9 @@ class StandupsController < ApplicationController
     @standups = Standup.all.sort{ |a,b| a.title.downcase <=> b.title.downcase }
   end
 
-  def edit
-    @standup = Standup.find(params[:id])
-  end
+  def edit; end
 
   def show
-    @standup = Standup.find_by(id: params[:id])
     if @standup
       session[:last_visited_standup] = params[:id]
       redirect_to standup_items_path(@standup)
@@ -34,8 +34,6 @@ class StandupsController < ApplicationController
   end
 
   def update
-    @standup = Standup.find(params[:id])
-
     if @standup.update(params[:standup])
       redirect_to @standup
     else
@@ -44,7 +42,6 @@ class StandupsController < ApplicationController
   end
 
   def destroy
-    @standup = Standup.find(params[:id])
     @standup.destroy
     redirect_to standups_path
   end
@@ -56,5 +53,16 @@ class StandupsController < ApplicationController
     else
       redirect_to standups_path
     end
+  end
+
+  private
+
+  def load_standup
+    @standup = Standup.find_by(id: params[:id])
+  end
+
+  def standup_timezone(&block)
+    return yield unless @standup
+    Time.use_zone(@standup.time_zone_name, &block)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,7 +32,7 @@ module ApplicationHelper
   end
 
   def date_label(item)
-    if item.date.present? && (item.kind == "Event" || item.date > Date.today)
+    if item.date.present? && (item.kind == "Event" || item.date > Time.zone.today)
       return item.date.strftime("%m/%d") + ": " if is_item_after_this_week(item)
       Date::DAYNAMES[item.date.wday].to_s + ": "
     end
@@ -47,6 +47,6 @@ module ApplicationHelper
   private
 
   def is_item_after_this_week(item)
-    item.date > Date.today.at_end_of_week
+    item.date > Time.zone.today.at_end_of_week
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,7 +23,7 @@ class Item < ActiveRecord::Base
   end
 
   def self.orphans
-    where(post_id: nil).where.not(kind: 'Event').where("date >= ? OR kind = 'Help' OR kind = 'Interesting'", Date.today).order("date ASC").group_by(&:kind)
+    where(post_id: nil).where.not(kind: 'Event').where("date >= ? OR kind = 'Help' OR kind = 'Interesting'", Time.zone.today).order("date ASC").group_by(&:kind)
   end
 
   def self.events_on_or_after(date, standup)
@@ -38,8 +38,8 @@ class Item < ActiveRecord::Base
   def self.for_post(standup)
     where(post_id: nil, bumped: false).
       where("standup_id = #{standup.id} OR standup_id IS NULL").
-      where("(kind != 'Event' OR date = ?)", Date.today).
-      where("date IS NULL OR date <= ?", Date.today)
+      where("(kind != 'Event' OR date = ?)", Time.zone.today).
+      where("date IS NULL OR date <= ?", Time.zone.today)
   end
 
   def possible_template_name

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -66,9 +66,16 @@ class Item < ActiveRecord::Base
   end
 
   private
+  def new_face?
+    kind == 'New face'
+  end
+
   def face_is_in_the_future
-    if new_record? && kind == 'New face' && (date || Time.at(0)).to_time < Time.now.beginning_of_day
-      errors.add(:base, "Please choose a date in present or future")
-    end
+    return unless new_record?
+    return unless new_face?
+    return unless date?
+    return unless date.beginning_of_day < Time.zone.now.beginning_of_day
+
+    errors.add(:base, 'Please choose a date in present or future')
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -36,11 +36,11 @@ class Post < ActiveRecord::Base
   end
 
   def events
-    Item.events_on_or_after(Date.today, standup)
+    Item.events_on_or_after(Time.zone.today, standup)
   end
 
   def public_events
-    Item.public.events_on_or_after(Date.today, standup)
+    Item.public.events_on_or_after(Time.zone.today, standup)
   end
 
   def items_by_type

--- a/app/models/standup_presenter.rb
+++ b/app/models/standup_presenter.rb
@@ -12,7 +12,7 @@ class StandupPresenter < SimpleDelegator
 
   def closing_message
     return @standup.closing_message if @standup.closing_message.present?
-    return "STRETCH! It's Floor Friday!" if Date.today.wday == 5
+    return "STRETCH! It's Floor Friday!" if Time.zone.today.wday == 5
     return nil if @standup.image_urls.present?
 
     STANDUP_CLOSINGS.sample

--- a/app/views/items/_date_picker.html.erb
+++ b/app/views/items/_date_picker.html.erb
@@ -1,6 +1,6 @@
 <div class='block'>
   <%= f.text_field :date,
-    value: item.date || Date.today,
+    value: item.date,
     "data-date-format" => "yyyy-mm-dd",
     :size => nil,
     :class => "wide",

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,6 @@ module Whiteboard
     # This will create an empty whitelist of attributes available for mass-assignment for all models
     # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
     # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = true
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/config/cf-production.yml
+++ b/config/cf-production.yml
@@ -1,5 +1,5 @@
 ---
 applications:
-- name: whiteboard-production
+- name: whiteboard-sydney
   command: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
   path: ../

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Whiteboard::Application.configure do
   # config.force_ssl = true
 
   # See everything in the log (default is :info)
-  # config.log_level = :debug
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags
   # config.log_tags = [ :subdomain, :uuid ]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20131017003125) do
     t.datetime "updated_at"
     t.string   "closing_message"
     t.string   "time_zone_name",      default: "Eastern Time (US & Canada)", null: false
+    t.text     "ip_addresses_string"
     t.string   "start_time_string",   default: "9:06am"
     t.text     "image_urls"
     t.string   "image_days"

--- a/script/deploy-staging.sh
+++ b/script/deploy-staging.sh
@@ -2,7 +2,7 @@
 
 set -ev
 
-if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+if [[ "$TRAVIS_BRANCH" == "master" ]] && "$TRAVIS_PULL_REQUEST" == false; then
   wget -q -O cf-cli.deb https://cli.run.pivotal.io/stable?release=debian64
   sudo dpkg -i cf-cli.deb
   cf login -u $CF_USERNAME -p $CF_PASSWORD -o pivotallabs -s whiteboard -a https://api.run.pivotal.io

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -18,12 +18,12 @@ describe ItemsController do
 
     it "should redirect to root on success" do
       post :create, valid_params
-      response.location.should == "http://test.host/standups/#{standup.id}"
+      expect(response.location).to eq "http://test.host/standups/#{standup.id}"
     end
 
     it "should render new on failure" do
       post :create, item: {}
-      response.should render_template 'items/new'
+      expect(response).to render_template 'items/new'
     end
 
     it "sets the post_id if one is provided" do
@@ -33,33 +33,33 @@ describe ItemsController do
           params[:item][:post_id] =  standup_post.to_param
         end)
       }.to change { standup_post.items.count }.by(1)
-      response.should redirect_to(edit_post_path(standup_post))
+      expect(response).to redirect_to(edit_post_path(standup_post))
     end
   end
 
   describe '#new' do
     it "should create a new Item object" do
       get :new, params
-      assigns[:item].should be_new_record
-      response.should render_template('items/new')
-      response.should be_ok
+      expect(assigns[:item]).to be_new_record
+      expect(response).to render_template('items/new')
+      expect(response).to be_ok
     end
 
     it "should render the custom template for the kind if there is one" do
       get :new, params.merge(item: { kind: 'New face' })
-      response.should render_template('items/new_new_face')
+      expect(response).to render_template('items/new_new_face')
     end
 
     it "uses the params to create the new item so you can set defaults in the link" do
       get :new, params.merge(item: { kind: 'Interesting' })
-      assigns[:item].kind.should == 'Interesting'
+      expect(assigns[:item].kind).to eq 'Interesting'
     end
 
     it "should set the author on the new Item" do
       session[:username] = "Barney Rubble"
       get :new, params
       item = assigns[:item]
-      item.author.should == "Barney Rubble"
+      expect(item.author).to eq "Barney Rubble"
     end
   end
 
@@ -70,10 +70,10 @@ describe ItemsController do
       interesting = create(:item, kind: "Interesting", standup: standup)
 
       get :index, params
-      assigns[:items]['New face'].should    == [ new_face ]
-      assigns[:items]['Help'].should        == [ help ]
-      assigns[:items]['Interesting'].should == [ interesting ]
-      response.should be_ok
+      expect(assigns[:items]['New face']).to eq [ new_face ]
+      expect(assigns[:items]['Help']).to eq [ help ]
+      expect(assigns[:items]['Interesting']).to eq [ interesting ]
+      expect(response).to be_ok
     end
 
     it "sorts the hash by date asc" do
@@ -81,7 +81,7 @@ describe ItemsController do
       old_help = create(:item, date: 4.days.ago, standup: standup)
 
       get :index, params
-      assigns[:items]['Help'].should == [ old_help, new_help ]
+      expect(assigns[:items]['Help']).to eq [ old_help, new_help ]
     end
 
     it "does not include items which are associated with a post" do
@@ -92,10 +92,10 @@ describe ItemsController do
       posted_item = create(:item, post: post, standup: standup)
 
       get :index, params
-      assigns[:items]['New face'].should    == [ new_face ]
-      assigns[:items]['Help'].should        == [ help ]
-      assigns[:items]['Interesting'].should == [ interesting ]
-      response.should be_ok
+      expect(assigns[:items]['New face']).to eq [ new_face ]
+      expect(assigns[:items]['Help']).to eq [ help ]
+      expect(assigns[:items]['Interesting']).to eq [ interesting ]
+      expect(response).to be_ok
     end
 
     it "does not include items associated with other standups" do
@@ -105,20 +105,20 @@ describe ItemsController do
 
       get :index, params
 
-      assigns[:items]['Event'].should include standup_event
-      assigns[:items]['Event'].should_not include other_standup_event
+      expect(assigns[:items]['Event']).to include standup_event
+      expect(assigns[:items]['Event']).to_not include other_standup_event
     end
   end
 
   describe "#presentation" do
     it "renders the deck template" do
       get :presentation, params
-      response.should render_template('deck')
+      expect(response).to render_template('deck')
     end
 
     it "loads the posts" do
       get :presentation, params
-      assigns[:items].should be
+      expect(assigns[:items]).to be
     end
 
     it "only loads items from the current standup" do
@@ -128,8 +128,8 @@ describe ItemsController do
 
       get :presentation, params
 
-      assigns[:items]['Event'].should include standup_event
-      assigns[:items]['Event'].should_not include other_standup_event
+      expect(assigns[:items]['Event']).to include standup_event
+      expect(assigns[:items]['Event']).to_not include other_standup_event
     end
   end
 
@@ -139,9 +139,9 @@ describe ItemsController do
 
       item = create(:item)
       delete :destroy, id: item.id
-      Item.find_by_id(item.id).should_not be
+      expect(Item.find_by_id(item.id)).to_not be
 
-      response.should redirect_to "the url we came from"
+      expect(response).to redirect_to "the url we came from"
     end
   end
 
@@ -149,14 +149,14 @@ describe ItemsController do
     it "should edit the item" do
       item = create(:item)
       get :edit, id: item.id
-      assigns[:item].should == item
-      response.should render_template 'items/new'
+      expect(assigns[:item]).to eq item
+      expect(response).to render_template 'items/new'
     end
 
     it "should render the custom template for the kind if there is one" do
       item = create(:new_face)
       get :edit, id: item.id
-      response.should render_template('items/new_new_face')
+      expect(response).to render_template('items/new_new_face')
     end
   end
 
@@ -164,7 +164,7 @@ describe ItemsController do
     it "should update the item" do
       item = create(:item)
       put :update, id: item.id, item: { title: "New Title" }
-      item.reload.title.should == "New Title"
+      expect(item.reload.title).to eq "New Title"
     end
 
     context "with a redirect_to param" do
@@ -172,7 +172,7 @@ describe ItemsController do
 
       it "redirects to the edit post page" do
         put :update, id: item.id, post_id: item.post, item: { title: "New Title" }, redirect_to: '/foo'
-        response.should redirect_to('/foo')
+        expect(response).to redirect_to('/foo')
       end
     end
 
@@ -181,7 +181,7 @@ describe ItemsController do
 
       it "redirects to the standup page" do
         put :update, id: item.id, post_id: item.post, item: { title: "New Title" }
-        response.should redirect_to(item.standup)
+        expect(response).to redirect_to(item.standup)
       end
     end
 
@@ -189,13 +189,13 @@ describe ItemsController do
       it "should render new" do
         item = create(:item)
         put :update, id: item.id, post_id: item.post, item: { title: "" }
-        response.should render_template('items/new')
+        expect(response).to render_template('items/new')
       end
 
       it "should render a custom template if there is one" do
         item = create(:new_face)
         put :update, id: item.id, post_id: item.post, item: { title: "" }
-        response.should render_template('items/new_new_face')
+        expect(response).to render_template('items/new_new_face')
       end
     end
   end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -5,10 +5,15 @@ describe ItemsController do
   let(:params) { {standup_id: standup.id} }
   before do
     request.session[:logged_in] = true
+    Timecop.freeze(Time.zone.local(2001,1,1, 20,00))
+  end
+
+  after do
+    Timecop.return
   end
 
   describe "#create" do
-    let(:valid_params) { {item: attributes_for(:item).merge(standup_id: standup.to_param)} }
+    let(:valid_params) { {item: attributes_for(:item).merge(standup_id: standup.to_param), standup_id: standup.to_param} }
 
     it "should allow you to create an item" do
       expect {
@@ -22,7 +27,7 @@ describe ItemsController do
     end
 
     it "should render new on failure" do
-      post :create, item: {}
+      post :create, item: {}, standup_id: standup.to_param
       expect(response).to render_template 'items/new'
     end
 
@@ -35,15 +40,13 @@ describe ItemsController do
       }.to change { standup_post.items.count }.by(1)
       expect(response).to redirect_to(edit_post_path(standup_post))
     end
+
+    it_behaves_like "an action occurring within the standup's timezone" do
+      after { post :create, valid_params }
+    end
   end
 
   describe '#new' do
-    before do
-      Timecop.freeze(Time.zone.local(2001,1,1, 20,00))
-    end
-    after do
-      Timecop.return
-    end
 
     it "should create a new Item object" do
       get :new, params

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -38,6 +38,13 @@ describe ItemsController do
   end
 
   describe '#new' do
+    before do
+      Timecop.freeze(Time.zone.local(2001,1,1, 20,00))
+    end
+    after do
+      Timecop.return
+    end
+
     it "should create a new Item object" do
       get :new, params
       expect(assigns[:item]).to be_new_record
@@ -60,6 +67,12 @@ describe ItemsController do
       get :new, params
       item = assigns[:item]
       expect(item.author).to eq "Barney Rubble"
+    end
+
+    it "should set the date of the item with respect to the local time zone" do
+      get :new, params
+      item = assigns[:item]
+      expect(item.date).to eq Date.new(2001, 1, 1)
     end
   end
 
@@ -100,8 +113,8 @@ describe ItemsController do
 
     it "does not include items associated with other standups" do
       other_standup = create(:standup)
-      standup_event = create(:item, kind: "Event", standup: standup, date: Date.tomorrow)
-      other_standup_event = create(:item, kind: "Event", standup: other_standup, date: Date.tomorrow)
+      standup_event = create(:item, kind: "Event", standup: standup, date: Time.zone.tomorrow)
+      other_standup_event = create(:item, kind: "Event", standup: other_standup, date: Time.zone.tomorrow)
 
       get :index, params
 
@@ -123,8 +136,8 @@ describe ItemsController do
 
     it "only loads items from the current standup" do
       other_standup = create(:standup)
-      other_standup_event = create(:item, standup: other_standup, date: Date.tomorrow, kind: "Event")
-      standup_event = create(:item, standup: standup, date: Date.tomorrow, kind: "Event")
+      other_standup_event = create(:item, standup: other_standup, date: Time.zone.tomorrow, kind: "Event")
+      standup_event = create(:item, standup: standup, date: Time.zone.tomorrow, kind: "Event")
 
       get :presentation, params
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -11,13 +11,13 @@ describe PostsController do
       expect do
         post :create, post: { title: "Standup 12/12/12"}, standup_id: standup.id
       end.to change { Post.count }.by(1)
-      response.should be_redirect
+      expect(response).to be_redirect
     end
 
     it "adopts all items" do
       item = create(:item, standup: standup)
       post :create, post: { title: "Standup 12/12/12"}, standup_id: standup.id
-      assigns[:post].items.should == [ item ]
+      expect(assigns[:post].items).to eq [ item ]
     end
   end
 
@@ -26,8 +26,8 @@ describe PostsController do
 
     it "shows the post for editing" do
       get :edit, id: post.id
-      assigns[:post].should == post
-      response.should be_ok
+      expect(assigns[:post]).to eq post
+      expect(response).to be_ok
     end
   end
 
@@ -36,9 +36,9 @@ describe PostsController do
 
     it "shows the post" do
       get :show, id: post.id
-      assigns[:post].should == post
-      response.should be_ok
-      response.body.should include(post.title)
+      expect(assigns[:post]).to eq post
+      expect(response).to be_ok
+      expect(response.body).to include(post.title)
     end
   end
 
@@ -47,8 +47,8 @@ describe PostsController do
 
     it "updates the post" do
       put :update, id: post.id, post: { title: "New Title", from: "Matthew & Matthew" }
-      post.reload.title.should == "New Title"
-      post.from.should == "Matthew & Matthew"
+      expect(post.reload.title).to eq "New Title"
+      expect(post.from).to eq "Matthew & Matthew"
     end
   end
 
@@ -58,21 +58,21 @@ describe PostsController do
     it "renders an index of posts" do
       post = create(:post, standup: standup)
       get :index, standup_id: standup.id
-      assigns[:posts].should == [ post ]
+      expect(assigns[:posts]).to eq [ post ]
     end
 
     it "does not include archived" do
       unarchived_post = create(:post, standup: standup)
       create(:post, archived: true, standup: standup)
       get :index, standup_id: standup.id
-      assigns[:posts].should == [ unarchived_post ]
+      expect(assigns[:posts]).to eq [ unarchived_post ]
     end
 
     it "does not include posts associated with other standups" do
       standup_post = create(:post, standup: standup)
       create(:post, standup: create(:standup))
       get :index, standup_id: standup.id
-      assigns[:posts].should == [ standup_post ]
+      expect(assigns[:posts]).to eq [ standup_post ]
     end
   end
 
@@ -85,9 +85,9 @@ describe PostsController do
 
       get :archived, standup_id: standup.id
 
-      assigns[:posts].should =~ [ archived_post  ]
-      response.should render_template('archived')
-      response.body.should include(archived_post.title)
+      expect(assigns[:posts]).to match [ archived_post  ]
+      expect(response).to render_template('archived')
+      expect(response.body).to include(archived_post.title)
     end
 
     it "lists the archived posts associated with the standup" do
@@ -96,8 +96,8 @@ describe PostsController do
 
       get :archived, standup_id: standup.id
 
-      assigns[:posts].should =~ [ standup_post  ]
-      response.body.should include(standup_post.title)
+      expect(assigns[:posts]).to match [ standup_post  ]
+      expect(response.body).to include(standup_post.title)
     end
   end
 
@@ -105,60 +105,60 @@ describe PostsController do
     it "sends the email" do
       post = create(:post, items: [ create(:item) ] )
       put :send_email, id: post.id
-      response.should redirect_to(edit_post_path(post))
-      ActionMailer::Base.deliveries.last.to.should == [post.standup.to_address]
+      expect(response).to redirect_to(edit_post_path(post))
+      expect(ActionMailer::Base.deliveries.last.to).to eq [post.standup.to_address]
     end
 
     it "does not allow resending" do
       post = create(:post, sent_at: Time.now )
       put :send_email, id: post.id
-      response.should redirect_to(edit_post_path(post))
-      flash[:error].should == "The post has already been emailed"
+      expect(response).to redirect_to(edit_post_path(post))
+      expect(flash[:error]).to eq "The post has already been emailed"
     end
   end
 
   describe "#post_to_blog" do
     before do
       @fakeWordpress = double("wordpress service", :"minimally_configured?" => true)
-      Rails.application.config.stub(:blogging_service) { @fakeWordpress }
+      allow(Rails.application.config).to receive(:blogging_service) { @fakeWordpress }
 
       @item = create(:item, public: true)
       @post = create(:post, items: [@item])
     end
 
     it "sets the post data on the blog post object" do
-      @fakeWordpress.stub(:send!)
+      allow(@fakeWordpress).to receive(:send!)
       blog_post = OpenStruct.new
-      BlogPost.should_receive(:new).and_return(blog_post)
+      expect(BlogPost).to receive(:new).and_return(blog_post)
 
       put :post_to_blog, id: @post.id
 
-      blog_post.title.should == @post.title
-      blog_post.body.should be
+      expect(blog_post.title).to eq @post.title
+      expect(blog_post.body).to be
     end
 
     it "posts to wordpress" do
-      @fakeWordpress.should_receive(:send!)
+      expect(@fakeWordpress).to receive(:send!)
 
       put :post_to_blog, id: @post.id
 
-      response.should redirect_to(edit_post_path(@post))
+      expect(response).to redirect_to(edit_post_path(@post))
     end
 
     it "marks it as posted" do
-      @fakeWordpress.stub(:send!)
+      allow(@fakeWordpress).to receive(:send!)
 
       put :post_to_blog, id: @post.id
 
-      @post.reload.blogged_at.should be
+      expect(@post.reload.blogged_at).to be
     end
 
     it "records the published post id" do
-      @fakeWordpress.stub(:send!).and_return("1234")
+      allow(@fakeWordpress).to receive(:send!).and_return("1234")
 
       put :post_to_blog, id: @post.id
 
-      @post.reload.blog_post_id.should eq "1234"
+      expect(@post.reload.blog_post_id).to eq "1234"
     end
 
     it "doesn't post to wordpress multiple times" do
@@ -167,20 +167,20 @@ describe PostsController do
 
       put :post_to_blog, id: @post.id
 
-      response.should redirect_to(edit_post_path(@post))
-      flash[:error].should == "The post has already been blogged"
+      expect(response).to redirect_to(edit_post_path(@post))
+      expect(flash[:error]).to eq "The post has already been blogged"
     end
 
     context 'unsuccessful post' do
 
       before do
-        @fakeWordpress.should_receive(:send!).and_raise(XMLRPC::FaultException.new(123, "Wrong size. Was 180, should be 131"))
+        expect(@fakeWordpress).to receive(:send!).and_raise(XMLRPC::FaultException.new(123, "Wrong size. Was 180, should be 131"))
         put :post_to_blog, id: @post.id
       end
 
       it "catches XMLRPC::FaultException and displays error message" do
-        flash[:error].should == "While posting to the blog, the service reported the following error: 'Wrong size. Was 180, should be 131', please repost."
-        response.should redirect_to(edit_post_path(@post))
+        expect(flash[:error]).to eq "While posting to the blog, the service reported the following error: 'Wrong size. Was 180, should be 131', please repost."
+        expect(response).to redirect_to(edit_post_path(@post))
       end
 
       it "it doesn't set blogged_at for an unsuccessful post" do
@@ -195,13 +195,13 @@ describe PostsController do
 
     it "archives the post" do
       put :archive, id: post.id
-      post.reload.should be_archived
-      response.should redirect_to post.standup
+      expect(post.reload).to be_archived
+      expect(response).to redirect_to post.standup
     end
 
     it "redirects back to index with a flash if it fails" do
       put :archive, id: 1234
-      response.should be_not_found
+      expect(response).to be_not_found
     end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,18 +2,18 @@ require 'rails_helper'
 
 describe SessionsController do
   describe '#create' do
-    before { ActionController::Base.any_instance.should_receive(:verify_authenticity_token).never }
+    before { expect_any_instance_of(ActionController::Base).to receive(:verify_authenticity_token).never }
 
     it "sets the session['logged_in'] to true" do
       request.env['omniauth.auth'] = { 'info' => { 'name' => 'Kocher' } }
       post :create
-      request.session['logged_in'].should == true
+      expect(request.session['logged_in']).to eq true
     end
 
     it "sets the session['username'] to the current user's name" do
       request.env['omniauth.auth'] = { 'info' => { 'name' => 'Dennis' } }
       post :create
-      request.session['username'].should == 'Dennis'
+      expect(request.session['username']).to eq 'Dennis'
     end
   end
 
@@ -21,7 +21,7 @@ describe SessionsController do
     it "sets the session['logged_in'] to false" do
       request.session['logged_in'] = true
       delete :destroy
-      request.session['logged_in'].should == false
+      expect(request.session['logged_in']).to eq false
     end
   end
 end

--- a/spec/controllers/standups_controller_spec.rb
+++ b/spec/controllers/standups_controller_spec.rb
@@ -13,7 +13,7 @@ describe StandupsController do
         expect do
           post :create, standup: {title: "Berlin", to_address: "berlin+standup@pivotallabs.com"}
         end.to change { Standup.count }.by(1)
-        response.should be_redirect
+        expect(response).to be_redirect
       end
     end
 
@@ -22,7 +22,7 @@ describe StandupsController do
         expect do
           post :create, standup: {}
         end.to change { Standup.count }.by(0)
-        response.should render_template 'standups/new'
+        expect(response).to render_template 'standups/new'
       end
     end
   end
@@ -30,8 +30,8 @@ describe StandupsController do
   describe "#new" do
     it "renders the new standups template" do
       get :new
-      response.should be_ok
-      response.should render_template 'standups/new'
+      expect(response).to be_ok
+      expect(response).to render_template 'standups/new'
     end
   end
 
@@ -43,7 +43,7 @@ describe StandupsController do
 
         get :index
 
-        response.should be_ok
+        expect(response).to be_ok
         expect(assigns[:standups]).to include(standup1, standup2)
       end
     end
@@ -56,7 +56,7 @@ describe StandupsController do
 
       get :index
 
-      response.should be_ok
+      expect(response).to be_ok
       expect(assigns[:standups]).to eq [first, second, third, fourth]
     end
   end
@@ -64,15 +64,15 @@ describe StandupsController do
   describe "#edit" do
     it "shows the post for editing" do
       get :edit, id: standup.id
-      assigns[:standup].should == standup
-      response.should be_ok
+      expect(assigns[:standup]).to eq standup
+      expect(response).to be_ok
     end
   end
 
   describe "#show" do
     it "redirects to the items page of the standup" do
       get :show, id: standup.id
-      response.body.should redirect_to standup_items_path(standup)
+expect(response.body).to redirect_to standup_items_path(standup)
     end
 
     it 'saves standup id to cookie' do
@@ -91,15 +91,15 @@ describe StandupsController do
     context "with valid params" do
       it "updates the post" do
         put :update, id: standup.id, standup: {title: "New Title"}
-        standup.reload.title.should == "New Title"
+        expect(standup.reload.title).to eq "New Title"
       end
     end
 
     context "with invalid params" do
       it "does not update the post" do
         put :update, id: standup.id, standup: {title: nil}
-        standup.reload.title.should == standup.title
-        response.should render_template 'standups/edit'
+        expect(standup.reload.title).to eq standup.title
+        expect(response).to render_template 'standups/edit'
       end
     end
   end
@@ -111,7 +111,7 @@ describe StandupsController do
       expect {
         post :destroy, id: standup.id
       }.to change(Standup, :count).by(-1)
-      response.should redirect_to standups_path
+      expect(response).to redirect_to standups_path
     end
   end
 

--- a/spec/controllers/standups_controller_spec.rb
+++ b/spec/controllers/standups_controller_spec.rb
@@ -67,6 +67,10 @@ describe StandupsController do
       expect(assigns[:standup]).to eq standup
       expect(response).to be_ok
     end
+
+    it_behaves_like "an action occurring within the standup's timezone" do
+      after { get :edit, id: standup.id }
+    end
   end
 
   describe "#show" do
@@ -85,6 +89,10 @@ describe StandupsController do
       expect(flash[:error]).to eq('A standup with the ID 12831 does not exist.')
       expect(response).to redirect_to(standups_path)
     end
+
+    it_behaves_like "an action occurring within the standup's timezone" do
+      after { get :show, id: 12831 }
+    end
   end
 
   describe "#update" do
@@ -102,6 +110,10 @@ describe StandupsController do
         expect(response).to render_template 'standups/edit'
       end
     end
+
+    it_behaves_like "an action occurring within the standup's timezone" do
+      after { put :update, id: standup.id, standup: {title: "New Title"} }
+    end
   end
 
   describe "#destroy" do
@@ -112,6 +124,10 @@ describe StandupsController do
         post :destroy, id: standup.id
       }.to change(Standup, :count).by(-1)
       expect(response).to redirect_to standups_path
+    end
+
+    it_behaves_like "an action occurring within the standup's timezone" do
+      after { post :destroy, id: standup.id }
     end
   end
 

--- a/spec/controllers/standups_controller_spec.rb
+++ b/spec/controllers/standups_controller_spec.rb
@@ -72,7 +72,7 @@ describe StandupsController do
   describe "#show" do
     it "redirects to the items page of the standup" do
       get :show, id: standup.id
-expect(response.body).to redirect_to standup_items_path(standup)
+      expect(response.body).to redirect_to standup_items_path(standup)
     end
 
     it 'saves standup id to cookie' do

--- a/spec/factories/item_factory.rb
+++ b/spec/factories/item_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :item do
     title "Focused specs are broken"
     kind "Help"
-    date Date.today
+    date Time.zone.today
 
     association :standup
   end
@@ -14,7 +14,7 @@ FactoryGirl.define do
   factory :new_face, class: Item do
     title "John"
     kind "New face"
-    date Date.today
+    date Time.zone.today
 
     association :standup
   end

--- a/spec/factories/item_factory.rb
+++ b/spec/factories/item_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :item do
     title "Focused specs are broken"
     kind "Help"
-    date Time.zone.today
+    date  { Time.zone.today }
 
     association :standup
   end
@@ -14,7 +14,7 @@ FactoryGirl.define do
   factory :new_face, class: Item do
     title "John"
     kind "New face"
-    date Time.zone.today
+    date { Time.zone.today }
 
     association :standup
   end

--- a/spec/features/adding_a_new_face_spec.rb
+++ b/spec/features/adding_a_new_face_spec.rb
@@ -19,13 +19,13 @@ describe "Adding new faces", js: true do
     find(:css, '[name="item[date]"]').click
     find(:css, '.next').click
 
-    find_field("item[date]").value.should == new_face_date
+    expect(find_field("item[date]").value).to eq new_face_date
     blur(page)
 
     click_on "Create New Face"
 
-    page.should have_content "Please choose a date in present or future"
-    #page.should have_content "Create New Face" #TODO: as of 2014-02-05, this captures a bug.
+    expect(page).to have_content "Please choose a date in present or future"
+    #expect(page).to have_content "Create New Face" #TODO: as of 2014-02-05, this captures a bug.
   end
 
   it "allows yesterday's new faces to post today" do
@@ -41,11 +41,11 @@ describe "Adding new faces", js: true do
 
       find('#create-post').click
 
-      page.should_not have_content "Unable to create post"
-      current_path.should_not eq(standup_items_path(standup))
+      expect(page).to_not have_content "Unable to create post"
+      expect(current_path).to_not eq(standup_items_path(standup))
 
       post = Post.last
-      post.items.should =~ [new_face]
+      expect(post.items).to match [new_face]
     end
   end
 end

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -88,92 +88,92 @@ describe "items", js: true do
     click_link(standup.title)
 
     within '.event' do
-      page.should have_css('.subheader.today', text: 'Today')
-      page.should have_css('.today + .item', text: 'Happy Hour')
-      page.should have_css('.subheader.tomorrow', text: 'Tomorrow')
-      page.should have_css('.tomorrow + .item', text: 'Baseball')
-      page.should have_css('.subheader.upcoming', text: 'Upcoming')
-      page.should have_css('.upcoming + .item', text: 'Party')
+      expect(page).to have_css('.subheader.today', text: 'Today')
+      expect(page).to have_css('.today + .item', text: 'Happy Hour')
+      expect(page).to have_css('.subheader.tomorrow', text: 'Tomorrow')
+      expect(page).to have_css('.tomorrow + .item', text: 'Baseball')
+      expect(page).to have_css('.subheader.upcoming', text: 'Upcoming')
+      expect(page).to have_css('.upcoming + .item', text: 'Party')
     end
 
     within '.new_face' do
-      page.should have_css('.subheader.today', text: 'Today')
-      page.should have_css('.today + .item', text: 'Johnathon McKenzie')
-      page.should have_css('.subheader.upcoming', text: 'Upcoming')
-      page.should have_css('.upcoming + .item', text: 'Jane Doe')
+      expect(page).to have_css('.subheader.today', text: 'Today')
+      expect(page).to have_css('.today + .item', text: 'Johnathon McKenzie')
+      expect(page).to have_css('.subheader.upcoming', text: 'Upcoming')
+      expect(page).to have_css('.upcoming + .item', text: 'Jane Doe')
     end
 
     within '.interesting' do
-      page.should have_css('.item', text: 'Linus Torvalds')
+      expect(page).to have_css('.item', text: 'Linus Torvalds')
       first('a[data-toggle]').click
-      page.should have_selector('.in')
-      page.should have_selector('code', text: 'inline code!')
-      page.should have_link('www.links.com')
+      expect(page).to have_selector('.in')
+      expect(page).to have_selector('code', text: 'inline code!')
+      expect(page).to have_link('www.links.com')
     end
 
     within '.win' do
-      page.should have_css('.item', text: 'Tracker iOS 7 app')
+      expect(page).to have_css('.item', text: 'Tracker iOS 7 app')
     end
 
     visit presentation_standup_items_path(standup)
 
     within 'section.deck-current' do
-      page.should have_content "Standup"
-      page.should have_css('.countdown')
+      expect(page).to have_content "Standup"
+      expect(page).to have_css('.countdown')
     end
     page.execute_script("$.deck('next')")
 
     within 'section.deck-current' do
-      page.should have_content "New faces"
-      page.should have_content "Today"
-      page.should have_content "Upcoming"
-      page.should have_content "Johnathon McKenzie"
+      expect(page).to have_content "New faces"
+      expect(page).to have_content "Today"
+      expect(page).to have_content "Upcoming"
+      expect(page).to have_content "Johnathon McKenzie"
     end
     page.execute_script("$.deck('next')")
 
-    find('section.deck-current').should have_content "Helps"
+    expect(find('section.deck-current')).to have_content "Helps"
     page.execute_script("$.deck('next')")
 
     within 'section.deck-current' do
-      page.should have_content "Interestings"
-      page.should have_content("Linux 3.2 out")
-      page.should have_content("Linus Torvalds")
-      page.should have_content("Rails 62 is out")
-      page.should_not have_selector('.in')
+      expect(page).to have_content "Interestings"
+      expect(page).to have_content("Linux 3.2 out")
+      expect(page).to have_content("Linus Torvalds")
+      expect(page).to have_content("Rails 62 is out")
+      expect(page).to_not have_selector('.in')
       first('a[data-toggle]').click
-      page.should have_selector('.in')
-      page.should have_content("Check it out:")
-      page.should have_link("www.links.com")
-      page.should have_selector("code", text: "inline code!")
+      expect(page).to have_selector('.in')
+      expect(page).to have_content("Check it out:")
+      expect(page).to have_link("www.links.com")
+      expect(page).to have_selector("code", text: "inline code!")
     end
     page.execute_script("$.deck('next')")
 
-    find('section.deck-current').should have_content "Events"
-    page.should have_css('section.deck-current', text: 'Today')
-    page.should have_css('.today + ul li', text: 'Happy Hour')
-    page.should have_css('section.deck-current', text: 'Tomorrow')
-    page.should have_css('.tomorrow + ul li', text: 'Baseball')
-    page.should have_css('section.deck-current', text: 'Upcoming')
-    page.should have_css('.upcoming + ul li', text: 'Party')
-    find('section.deck-current').should_not have_content "Meetup"
-    find('section.deck-current').should_not have_content("Rails 62 is out")
+    expect(find('section.deck-current')).to have_content "Events"
+    expect(page).to have_css('section.deck-current', text: 'Today')
+    expect(page).to have_css('.today + ul li', text: 'Happy Hour')
+    expect(page).to have_css('section.deck-current', text: 'Tomorrow')
+    expect(page).to have_css('.tomorrow + ul li', text: 'Baseball')
+    expect(page).to have_css('section.deck-current', text: 'Upcoming')
+    expect(page).to have_css('.upcoming + ul li', text: 'Party')
+    expect(find('section.deck-current')).to_not have_content "Meetup"
+    expect(find('section.deck-current')).to_not have_content("Rails 62 is out")
     page.execute_script("$.deck('next')")
 
-    find('section.deck-current').should have_content "Wins"
-    page.should have_css('section.deck-current', text: 'Tracker iOS 7 app')
-    find('section.deck-current').should_not have_content 'Happy Hour'
-    find('section.deck-current').should_not have_content 'Baseball'
+    expect(find('section.deck-current')).to have_content "Wins"
+    expect(page).to have_css('section.deck-current', text: 'Tracker iOS 7 app')
+    expect(find('section.deck-current')).to_not have_content 'Happy Hour'
+    expect(find('section.deck-current')).to_not have_content 'Baseball'
     page.execute_script("$.deck('next')")
 
     within 'section.deck-current' do
-      page.should_not have_content "Wins"
-      page.should have_content "Woohoo"
-      page.should have_css('img[src="http://example.com/bar.png"]')
+      expect(page).to_not have_content "Wins"
+      expect(page).to have_content "Woohoo"
+      expect(page).to have_css('img[src="http://example.com/bar.png"]')
     end
 
     all('.exit-presentation').first.click
 
-    current_path.should == standup_items_path(standup)
+    expect(current_path).to eq standup_items_path(standup)
   end
 
   it 'does not let you create wins if the feature flag is off' do
@@ -183,7 +183,7 @@ describe "items", js: true do
     visit '/'
     click_link(standup.title)
 
-    page.should_not have_css('a[data-kind="Win"] i')
+    expect(page).to_not have_css('a[data-kind="Win"] i')
   end
 
   it 'hides wins if there are none' do
@@ -191,56 +191,56 @@ describe "items", js: true do
     visit presentation_standup_items_path(standup)
 
     within 'section.deck-current' do
-      page.should have_content "Standup"
-      page.should have_css('.countdown')
+      expect(page).to have_content "Standup"
+      expect(page).to have_css('.countdown')
     end
     page.execute_script("$.deck('next')")
 
-    find('section.deck-current').should have_content "New faces"
+    expect(find('section.deck-current')).to have_content "New faces"
     page.execute_script("$.deck('next')")
-    find('section.deck-current').should have_content "Helps"
+    expect(find('section.deck-current')).to have_content "Helps"
     page.execute_script("$.deck('next')")
-    find('section.deck-current').should have_content "Interestings"
+    expect(find('section.deck-current')).to have_content "Interestings"
     page.execute_script("$.deck('next')")
-    find('section.deck-current').should have_content "Events"
+    expect(find('section.deck-current')).to have_content "Events"
     page.execute_script("$.deck('next')")
 
     within 'section.deck-current' do
-      page.should_not have_content "Wins"
-      page.should have_content "Woohoo"
+      expect(page).to_not have_content "Wins"
+      expect(page).to have_content "Woohoo"
     end
   end
 
   describe "the bottom navbar" do
     context "when the screen width starts at or above 737px" do
       it "locks to the bottom of the screen but unlocks whenever the width goes below 737px" do
-        page.driver.resize_window 737, 2000
+        page.current_window.resize_to 737, 2000
 
         login
         visit '/'
         click_link(standup.title)
 
-        page.find('div.content-wrapper').should have_css('.navbar-fixed-bottom')
-        page.driver.resize_window 736, 2000
-        page.find('div.content-wrapper').should_not have_css('.navbar-fixed-bottom')
-        page.driver.resize_window 737, 2000
-        page.find('div.content-wrapper').should have_css('.navbar-fixed-bottom')
+        expect(page.find('div.content-wrapper')).to have_css('.navbar-fixed-bottom')
+        page.current_window.resize_to 736, 2000
+        expect(page.find('div.content-wrapper')).to_not have_css('.navbar-fixed-bottom')
+        page.current_window.resize_to 737, 2000
+        expect(page.find('div.content-wrapper')).to have_css('.navbar-fixed-bottom')
       end
     end
 
     context "when the screen width starts below 737px" do
       it "is unlocked from the bottom of the screen but locks whenever the width goes above 737px" do
-        page.driver.resize_window 736, 2000
+        page.current_window.resize_to 736, 2000
 
         login
         visit '/'
         click_link(standup.title)
 
-        page.find('div.content-wrapper').should_not have_css('.navbar-fixed-bottom')
-        page.driver.resize_window 737, 2000
-        page.find('div.content-wrapper').should have_css('.navbar-fixed-bottom')
-        page.driver.resize_window 736, 2000
-        page.find('div.content-wrapper').should_not have_css('.navbar-fixed-bottom')
+        expect(page.find('div.content-wrapper')).to_not have_css('.navbar-fixed-bottom')
+        page.current_window.resize_to 737, 2000
+        expect(page.find('div.content-wrapper')).to have_css('.navbar-fixed-bottom')
+        page.current_window.resize_to 736, 2000
+        expect(page.find('div.content-wrapper')).to_not have_css('.navbar-fixed-bottom')
       end
     end
   end

--- a/spec/features/items_spec.rb
+++ b/spec/features/items_spec.rb
@@ -9,7 +9,7 @@ describe "items", js: true do
   let(:date_five_days) { (timezone.now + 5.days).strftime("%Y-%m-%d") }
 
   before do
-    Timecop.travel(Time.local(2013, 9, 2, 12, 0, 0)) #monday
+    Timecop.travel(Time.zone.local(2013, 9, 2, 12, 0, 0)) #monday
     ENV["ENABLE_WINS"] = 'true'
   end
 

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -18,11 +18,11 @@ describe "posts" do
       end
 
       it "displays the name of the post" do
-        page.should have_content "Archived Post"
+        expect(page).to have_content "Archived Post"
       end
 
       it "displays items in a post" do
-        page.should have_content "I am helping people"
+        expect(page).to have_content "I am helping people"
       end
     end
   end

--- a/spec/features/publishing_spec.rb
+++ b/spec/features/publishing_spec.rb
@@ -51,7 +51,7 @@ describe "publishing", js: true do
 
     find('a[data-kind="Event"] i').click
     fill_in 'item_title', :with => "Happy Hour"
-    fill_in 'item_date', :with => Date.today
+    fill_in 'item_date', :with => Time.zone.today
     select 'Camelot', from: 'item[standup_id]'
     click_on 'Post to Blog'
     click_button 'Create Item'
@@ -79,7 +79,7 @@ describe "publishing", js: true do
 
     find('a[data-kind="Event"] i').click
     fill_in 'item_title', :with => "Happy Hour"
-    fill_in 'item_date', :with => Date.today
+    fill_in 'item_date', :with => Time.zone.today
     select 'Camelot', from: 'item[standup_id]'
     click_on 'Post to Blog'
     click_button 'Create Item'

--- a/spec/features/publishing_spec.rb
+++ b/spec/features/publishing_spec.rb
@@ -7,11 +7,11 @@ describe "publishing", js: true do
     login
     visit '/'
 
-    WordpressService.any_instance.stub(:minimally_configured?).and_return(true)
+    allow_any_instance_of(WordpressService).to receive(:minimally_configured?).and_return(true)
   end
 
   it "does not allow publishing to blog and email when no public content" do
-    WordpressService.any_instance.should_not_receive(:send!)
+    expect_any_instance_of(WordpressService).to_not receive(:send!)
     click_link(standup.title)
 
     fill_in "Blogger Name(s)", with: "Me"
@@ -20,16 +20,16 @@ describe "publishing", js: true do
     page.evaluate_script('window.confirm = function() { return true; }')
     click_on "Create Post"
 
-    page.should have_content("Please update these items with any new information from standup:")
+    expect(page).to have_content("Please update these items with any new information from standup:")
 
-    page.should have_css('p[disabled="disabled"]', text: 'Send Email')
+    expect(page).to have_css('p[disabled="disabled"]', text: 'Send Email')
     within('#publish', text: 'Please double check this email for accuracy.') do
-      page.should have_content("There is no content to publish")
+      expect(page).to have_content("There is no content to publish")
     end
 
-    page.should have_css('p[disabled="disabled"]', text: 'Post Blog Entry')
+    expect(page).to have_css('p[disabled="disabled"]', text: 'Post Blog Entry')
     within('#publish', text: 'Please double check the blog post.') do
-      page.should have_content("There is no content to publish")
+      expect(page).to have_content("There is no content to publish")
     end
 
     within "div.block.header", text: "NEW FACES" do
@@ -40,12 +40,12 @@ describe "publishing", js: true do
 
     click_on "Create New Face"
 
-    find_link("Send Email").should be
-    page.should have_css('p[disabled="disabled"]', text: 'Post Blog Entry')
+    expect(find_link("Send Email")).to be
+    expect(page).to have_css('p[disabled="disabled"]', text: 'Post Blog Entry')
   end
 
   it "allows reposting if error returned from wordpress" , js: true do
-    WordpressService.any_instance.should_receive(:send!).and_raise(XMLRPC::FaultException.new(123, "Wrong size. Was 180, should be 131"))
+    expect_any_instance_of(WordpressService).to receive(:send!).and_raise(XMLRPC::FaultException.new(123, "Wrong size. Was 180, should be 131"))
     click_link(standup.title)
 
 
@@ -65,15 +65,15 @@ describe "publishing", js: true do
     click_on 'Post Blog Entry'
 
     within '.alert.alert-danger' do
-      page.should have_content('Wrong size. Was 180, should be 131')
+      expect(page).to have_content('Wrong size. Was 180, should be 131')
     end
 
-    page.should_not have_content("This entry was posted at")
-    page.should have_css('a', text: 'Post Blog Entry')
+    expect(page).to_not have_content("This entry was posted at")
+    expect(page).to have_css('a', text: 'Post Blog Entry')
   end
 
   it "shows the URL the post was published to" , js: true do
-    WordpressService.any_instance.should_receive(:send!).and_return("best-post-eva")
+    expect_any_instance_of(WordpressService).to receive(:send!).and_return("best-post-eva")
     click_link(standup.title)
 
 
@@ -92,7 +92,7 @@ describe "publishing", js: true do
 
     click_on 'Post Blog Entry'
 
-    page.should have_content("This entry was posted at")
-    page.should have_css('a', text: 'best-post-eva')
+    expect(page).to have_content("This entry was posted at")
+    expect(page).to have_css('a', text: 'best-post-eva')
   end
 end

--- a/spec/features/standups_spec.rb
+++ b/spec/features/standups_spec.rb
@@ -6,7 +6,7 @@ describe "standups", :js do
     visit '/'
     FactoryGirl.create(:standup)
 
-    find('h2').should have_content 'CHOOSE A STANDUP'
+    expect(find('h2')).to have_content 'CHOOSE A STANDUP'
     click_link('New Standup')
 
     fill_in 'standup_title', with: "London"
@@ -19,37 +19,37 @@ describe "standups", :js do
     click_button 'Create Standup'
 
     click_link('All Standups')
-    page.should have_content 'LONDON'
+    expect(page).to have_content 'LONDON'
     click_link('London')
   end
 
   it "creates new standups", js: true do
     current_page = current_url
-    current_page.should match(/http:\/\/127\.0\.0\.1:\d*\/standups\/\d*/)
-    find('.navbar-fixed-top').should have_content 'London Whiteboard'
+    expect(current_page).to match(/http:\/\/127\.0\.0\.1:\d*\/standups\/\d*/)
+    expect(find('.navbar-fixed-top')).to have_content 'London Whiteboard'
 
     page.find('a.btn.btn-navbar').click if page.has_css?('.btn.btn-navbar')
     page.find('a.posts', text: 'Posts').click
-    page.should have_content 'Current Post'
+    expect(page).to have_content 'Current Post'
     click_link('Current Post')
-    page.should have_content 'London Whiteboard'
-    current_page.should match(/http:\/\/127\.0\.0\.1:\d*\/standups\/\d*/)
+    expect(page).to have_content 'London Whiteboard'
+    expect(current_page).to match(/http:\/\/127\.0\.0\.1:\d*\/standups\/\d*/)
 
     click_on_preferences(page)
-    page.should have_css('input[value="London"]')
-    page.should have_css('input[value="[Standup][ENG]"]')
-    page.should have_css('input[value="all@pivotallabs.com"]')
-    page.should have_css('input[value="Woohoo"]')
-    page.should have_css('option[value="Mountain Time (US & Canada)"][selected]')
-    page.should have_css('input[value="10:00am"]')
+    expect(page).to have_css('input[value="London"]')
+    expect(page).to have_css('input[value="[Standup][ENG]"]')
+    expect(page).to have_css('input[value="all@pivotallabs.com"]')
+    expect(page).to have_css('input[value="Woohoo"]')
+    expect(page).to have_css('option[value="Mountain Time (US & Canada)"][selected]')
+    expect(page).to have_css('input[value="10:00am"]')
   end
 
   it "allows you to delete existing standups", js: true do
     click_on_preferences(page)
     click_on 'Delete Standup'
 
-    current_url.should match(/http:\/\/127\.0\.0\.1:\d*\/standups$/)
-    page.should_not have_content 'London Whiteboard'
+expect(current_url).to match(/http:\/\/127\.0\.0\.1:\d*\/standups$/)
+    expect(page).to_not have_content 'London Whiteboard'
   end
 
   it 'takes you to the last standup you viewed' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,23 +8,23 @@ describe ApplicationHelper do
     before { create(:post, standup: standup) }
 
     it "can count" do
-      helper.pending_post_count(standup).should == 1
+      expect(helper.pending_post_count(standup)).to eq 1
     end
 
     it "doesn't count unassociated standups" do
-      helper.pending_post_count(other_standup).should == 0
+      expect(helper.pending_post_count(other_standup)).to eq 0
     end
   end
 
   describe "#show_or_edit_post_path" do
     it "links to edit if not archived" do
       post = create(:post)
-      helper.show_or_edit_post_path(post).should == edit_post_path(post)
+      expect(helper.show_or_edit_post_path(post)).to eq edit_post_path(post)
     end
 
     it "links to show if archived" do
       post = create(:post, archived: true)
-      helper.show_or_edit_post_path(post).should == post_path(post)
+      expect(helper.show_or_edit_post_path(post)).to eq post_path(post)
     end
   end
 
@@ -33,18 +33,18 @@ describe ApplicationHelper do
 
     context "the item is an event" do
       let(:item) { Item.new(kind: "Interesting", title: "Not Interesting", date: Date.tomorrow) }
-      it { should == "#{item.date.strftime("%A(%m/%d)")}: #{item.title}" }
+      it { is_expected.to eq "#{item.date.strftime("%A(%m/%d)")}: #{item.title}" }
     end
 
     context "the item is not an event" do
       context "the item does not have a date" do
         let(:item) { Item.new(kind: "Interesting", title: "Not Interesting") }
-        it { should == item.title }
+        it { is_expected.to eq item.title }
       end
 
       context "the item does have a date" do
         let(:item) { Item.new(kind: "Interesting", title: "Not Interesting", date: Date.tomorrow) }
-        it { should == "#{item.date.strftime("%A(%m/%d)")}: #{item.title}" }
+        it { is_expected.to eq "#{item.date.strftime("%A(%m/%d)")}: #{item.title}" }
       end
     end
   end
@@ -55,7 +55,7 @@ describe ApplicationHelper do
 
       it "returns nothing" do
         label = helper.date_label(item)
-        label.should be_blank
+        expect(label).to be_blank
       end
     end
 
@@ -64,7 +64,7 @@ describe ApplicationHelper do
         it "displays day of week" do
           event = create(:item, kind: "Event", date: Date.new(2012, 11, 05))
           label = helper.date_label(event)
-          label.should == "Monday: "
+          expect(label).to eq "Monday: "
         end
       end
 
@@ -78,31 +78,31 @@ describe ApplicationHelper do
 
           it "returns nothing" do
             label = helper.date_label(item)
-            label.should be_blank
+            expect(label).to be_blank
           end
         end
 
         describe "when the date is in the future" do
           before do
-            Date.stub(today: Date.new(2012, 11, 05))
+            allow(Date).to receive(:today).and_return(Date.new(2012, 11, 05))
             item.date = Date.new(2012, 11, 07)
           end
 
           it "returns the day of the week" do
             label = helper.date_label(item)
-            label.should == "Wednesday: "
+            expect(label).to eq "Wednesday: "
           end
         end
 
         describe "when the date is more than a week away" do
           before do
-            Date.stub(today: Date.new(2012, 11, 04))
+            allow(Date).to receive(:today).and_return(Date.new(2012, 11, 04))
             item.date = Date.new(2012, 11, 22)
           end
 
           it "displays the date rather than the day name" do
             label = helper.date_label(item)
-            label.should == "11/22: "
+            expect(label).to eq "11/22: "
           end
         end
       end
@@ -111,13 +111,13 @@ describe ApplicationHelper do
 
   describe "#wordpress_enabled?" do
     it "returns true if the app's blogging service is minimally configured" do
-      Rails.application.config.blogging_service.stub(:minimally_configured?).and_return(true)
-      helper.wordpress_enabled?.should == true
+      allow(Rails.application.config.blogging_service).to receive(:minimally_configured?).and_return(true)
+      expect(helper.wordpress_enabled?).to eq true
     end
 
     it "returns false otherwise" do
-      Rails.application.config.blogging_service.stub(:minimally_configured?).and_return(false)
-      helper.wordpress_enabled?.should == false
+      allow(Rails.application.config.blogging_service).to receive(:minimally_configured?).and_return(false)
+      expect(helper.wordpress_enabled?).to eq false
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -32,7 +32,7 @@ describe ApplicationHelper do
     subject { helper.format_title(item) }
 
     context "the item is an event" do
-      let(:item) { Item.new(kind: "Interesting", title: "Not Interesting", date: Date.tomorrow) }
+      let(:item) { Item.new(kind: "Interesting", title: "Not Interesting", date: Time.zone.tomorrow) }
       it { is_expected.to eq "#{item.date.strftime("%A(%m/%d)")}: #{item.title}" }
     end
 
@@ -43,7 +43,7 @@ describe ApplicationHelper do
       end
 
       context "the item does have a date" do
-        let(:item) { Item.new(kind: "Interesting", title: "Not Interesting", date: Date.tomorrow) }
+        let(:item) { Item.new(kind: "Interesting", title: "Not Interesting", date: Time.zone.tomorrow) }
         it { is_expected.to eq "#{item.date.strftime("%A(%m/%d)")}: #{item.title}" }
       end
     end
@@ -83,10 +83,13 @@ describe ApplicationHelper do
         end
 
         describe "when the date is in the future" do
+
           before do
-            allow(Date).to receive(:today).and_return(Date.new(2012, 11, 05))
+            Timecop.freeze(Time.zone.local(2012,11,05, 20,00))
             item.date = Date.new(2012, 11, 07)
           end
+
+          after { Timecop.return }
 
           it "returns the day of the week" do
             label = helper.date_label(item)
@@ -96,9 +99,11 @@ describe ApplicationHelper do
 
         describe "when the date is more than a week away" do
           before do
-            allow(Date).to receive(:today).and_return(Date.new(2012, 11, 04))
+            Timecop.freeze(Time.zone.local(2012,11,04, 20,00))
             item.date = Date.new(2012, 11, 22)
           end
+
+          after { Timecop.return }
 
           it "displays the date rather than the day name" do
             label = helper.date_label(item)

--- a/spec/mailers/post_mailer_spec.rb
+++ b/spec/mailers/post_mailer_spec.rb
@@ -8,28 +8,28 @@ describe PostMailer do
     let(:mail) { PostMailer.send_to_all(post, destination, from_address, post.standup_id) }
 
     it 'sets the title to be the posts title' do
-      mail.subject.should == post.title_for_email
+      expect(mail.subject).to eq post.title_for_email
     end
 
     it 'sets the from address' do
-      mail.from.should == [from_address]
+      expect(mail.from).to eq [from_address]
     end
 
     it 'renders the items in the body of the message' do
-      mail.text_part.body.should include(post.items.first.title)
+expect(mail.text_part.body).to include(post.items.first.title)
     end
 
     it 'includes a link to the standup' do
-      mail.text_part.body.should include(standup_items_url(post.standup))
+expect(mail.text_part.body).to include(standup_items_url(post.standup))
     end
 
     it 'properly deals with & and " by not escaping them' do
-      mail.text_part.body.should include('"Winning"')
-      mail.text_part.body.should include('Like this & like "that"')
+expect(mail.text_part.body).to include('"Winning"')
+expect(mail.text_part.body).to include('Like this & like "that"')
     end
 
     it 'delivers to the specified address' do
-      mail.to.should == [destination]
+      expect(mail.to).to eq [destination]
     end
   end
 end

--- a/spec/models/blog_post_spec.rb
+++ b/spec/models/blog_post_spec.rb
@@ -10,34 +10,34 @@ describe BlogPost do
     end
 
     it 'returns a properly formed hash' do
-      subject.post_hash.should == {
+      expect(subject.post_hash).to eq ({
         'title' => 'title',
         'description' => 'description',
         'mt_keywords' => 'keywords',
         'categories' => 'categories'
-      }
+      })
     end
   end
 
   describe '#keywords' do
     it 'returns keywords if set' do
       subject.keywords = 'keywords'
-      subject.keywords.should == 'keywords'
+      expect(subject.keywords).to eq 'keywords'
     end
 
     it 'returns [] if no keywords were set' do
-      subject.keywords.should == []
+      expect(subject.keywords).to eq []
     end
   end
 
   describe '#categories' do
     it 'returns categories if set' do
       subject.categories = 'categories'
-      subject.categories.should == 'categories'
+      expect(subject.categories).to eq 'categories'
     end
-    
+
     it 'returns ["standup"] if no categories were set' do
-      subject.categories.should == ['standup']
+      expect(subject.categories).to eq ['standup']
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,13 +15,13 @@ describe Item do
   end
 
   describe "associations" do
-    it { should belong_to(:post) }
-    it { should belong_to(:standup) }
+    it { is_expected.to belong_to(:post) }
+    it { is_expected.to belong_to(:standup) }
   end
 
   describe "validations" do
-    it { should validate_presence_of(:title) }
-    it { should validate_presence_of(:standup) }
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:standup) }
 
     context 'New Faces' do
       let(:item) { build(:new_face) }
@@ -32,7 +32,7 @@ describe Item do
         it 'should disallow a past creation date' do
           Timecop.freeze do
             item = build(:new_face, date: yesterday)
-            item.should_not be_valid
+            expect(item).to_not be_valid
           end
         end
       end
@@ -47,7 +47,7 @@ describe Item do
         it 'should allow a past creation date' do
           Timecop.freeze('2014-04-28 14:42:11') do
             item.post_id = 1
-            item.should be_valid
+            expect(item).to be_valid
           end
         end
       end
@@ -59,7 +59,7 @@ describe Item do
       ['Help', 'Interesting', 'Event', 'Win'].each do |kind|
         it kind do
           item.kind = kind
-          item.should be_valid
+          expect(item).to be_valid
         end
       end
     end
@@ -68,19 +68,19 @@ describe Item do
       it "is valid with a date in the future" do
         item.kind = 'New face'
         item.date = Date.tomorrow
-        item.should be_valid
+        expect(item).to be_valid
       end
     end
 
     it "should not allow other kinds" do
       item.kind = "foobar"
-      item.should_not be_valid
+      expect(item).to_not be_valid
     end
   end
 
   describe "defaults" do
     it "defaults public to false" do
-      Item.new.public.should == false
+      expect(Item.new.public).to eq false
     end
   end
 
@@ -100,16 +100,16 @@ describe Item do
       post.items << event_with_post
     end
 
-    it { should_not include event_before_date }
-    it { should include event_on_date }
-    it { should include event_after_date }
+    it { is_expected.to_not include event_before_date }
+    it { is_expected.to include event_on_date }
+    it { is_expected.to include event_after_date }
 
     it "orders the events by date" do
-      subject.should == [event_on_date, event_after_date]
+      expect(subject).to eq [event_on_date, event_after_date]
     end
 
     it "does not include events that have a post_id set" do
-      subject.should_not include event_with_post
+      expect(subject).to_not include event_with_post
     end
   end
 
@@ -135,35 +135,35 @@ describe Item do
     let!(:event_tomorrow) { create(:item, date: Date.tomorrow, kind: 'Event', standup: standup) }
 
     it "includes item with no post id" do
-      should include item_with_no_post_id
-      should_not include item_with_post_id
+      expect(subject).to include item_with_no_post_id
+      expect(subject).to_not include item_with_post_id
     end
 
     it "includes non-bumped items" do
-      should include item_not_bumped
-      should_not include bumped_item
+      expect(subject).to include item_not_bumped
+      expect(subject).to_not include bumped_item
     end
 
     it "includes items with dates, but only for today" do
-      should include item_for_today
-      should_not include item_for_tomorrow
-      should include item_with_no_date
+      expect(subject).to include item_for_today
+      expect(subject).to_not include item_for_tomorrow
+      expect(subject).to include item_with_no_date
     end
 
     it "does not include events in the future" do
-      should_not include event_tomorrow
+      expect(subject).to_not include event_tomorrow
     end
 
     it "includes events from today" do
-      should include event_today
+      expect(subject).to include event_today
     end
 
     it "combines all of the above" do
-      should =~ [item_with_no_post_id, item_not_bumped, item_for_today, item_with_no_date, event_today]
+      expect(subject).to match_array [item_with_no_post_id, item_not_bumped, item_for_today, item_with_no_date, event_today]
     end
 
     it "does not include items for other standups" do
-      should_not include item_for_different_standup
+      expect(subject).to_not include item_for_different_standup
     end
   end
 
@@ -173,8 +173,8 @@ describe Item do
 
     let(:standup) do
       standup = Standup.new
-      standup.stub(:date_today).and_return(today)
-      standup.stub(:date_tomorrow).and_return(tomorrow)
+      allow(standup).to receive(:date_today).and_return(today)
+      allow(standup).to receive(:date_tomorrow).and_return(tomorrow)
       standup
     end
 
@@ -184,7 +184,7 @@ describe Item do
         item.standup = standup
       end
 
-      item.relative_date.should == :today
+      expect(item.relative_date).to eq :today
     end
 
     it 'returns :tomorrow for an event taking place tomorrow' do
@@ -193,7 +193,7 @@ describe Item do
         item.standup = standup
       end
 
-      item.relative_date.should == :tomorrow
+      expect(item.relative_date).to eq :tomorrow
     end
 
     it 'returns :upcoming for an event taking place after tomorrow' do
@@ -202,7 +202,7 @@ describe Item do
         item.standup = standup
       end
 
-      item.relative_date.should == :upcoming
+      expect(item.relative_date).to eq :upcoming
     end
   end
 
@@ -211,14 +211,14 @@ describe Item do
       old_help = FactoryGirl.create(:item, kind: 'Help', date: 2.days.ago)
       interesting = FactoryGirl.create(:item, kind: 'Interesting')
 
-      Item.orphans.should == {'Help' => [old_help], 'Interesting' => [interesting]}
+      expect(Item.orphans).to eq({'Help' => [old_help], 'Interesting' => [interesting]})
     end
 
     it 'returns items in date asc order' do
       interesting = FactoryGirl.create(:item, kind: 'Interesting')
       old_interesting = FactoryGirl.create(:item, kind: 'Interesting', date: 2.days.ago)
 
-      Item.orphans.should == {'Interesting' => [old_interesting, interesting]}
+      expect(Item.orphans).to eq({'Interesting' => [old_interesting, interesting]})
     end
   end
 
@@ -228,7 +228,7 @@ describe Item do
       FactoryGirl.create(:item, kind: 'Event')
       FactoryGirl.create(:item, kind: 'Help', date: Date.yesterday)
 
-      Item.orphans.length.should == 1
+      expect(Item.orphans.length).to eq 1
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -27,7 +27,7 @@ describe Item do
       let(:item) { build(:new_face) }
 
       context 'when new' do
-        let(:yesterday) { Date.today - 1.day }
+        let(:yesterday) { Time.zone.today - 1.day }
 
         it 'should disallow a past creation date' do
           Timecop.freeze do
@@ -67,7 +67,7 @@ describe Item do
     describe "New face" do
       it "is valid with a date in the future" do
         item.kind = 'New face'
-        item.date = Date.tomorrow
+        item.date = Time.zone.tomorrow
         expect(item).to be_valid
       end
     end
@@ -125,14 +125,14 @@ describe Item do
     let!(:item_not_bumped) { create(:item, bumped: false, kind: "Help", standup: standup) }
     let!(:bumped_item) { create(:item, bumped: true, kind: "Help", standup: standup) }
 
-    let!(:item_for_today) { create(:item, date: Date.today, kind: "Help", standup: standup) }
+    let!(:item_for_today) { create(:item, date: Time.zone.today, kind: "Help", standup: standup) }
     let!(:item_with_no_date) { create(:item, date: nil, kind: "Help", standup: standup) }
-    let!(:item_for_tomorrow) { create(:item, date: Date.tomorrow, kind: "Help", standup: standup) }
+    let!(:item_for_tomorrow) { create(:item, date: Time.zone.tomorrow, kind: "Help", standup: standup) }
 
     let!(:item_for_different_standup) { create(:item, date: nil, kind: "Help", standup: other_standup) }
 
-    let!(:event_today) { create(:item, date: Date.today, kind: 'Event', standup: standup) }
-    let!(:event_tomorrow) { create(:item, date: Date.tomorrow, kind: 'Event', standup: standup) }
+    let!(:event_today) { create(:item, date: Time.zone.today, kind: 'Event', standup: standup) }
+    let!(:event_tomorrow) { create(:item, date: Time.zone.tomorrow, kind: 'Event', standup: standup) }
 
     it "includes item with no post id" do
       expect(subject).to include item_with_no_post_id

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -27,10 +27,10 @@ describe Item do
       let(:item) { build(:new_face) }
 
       context 'when new' do
-        let(:yesterday) { Time.zone.today - 1.day }
+        let(:yesterday)  { (Time.zone.today - 1.day).to_time }
 
         it 'should disallow a past creation date' do
-          Timecop.freeze do
+          Timecop.freeze('2001-01-01 09:00') do
             item = build(:new_face, date: yesterday)
             expect(item).to_not be_valid
           end
@@ -39,7 +39,7 @@ describe Item do
 
       context 'when updating' do
         before do
-          Timecop.freeze('2014-04-14 12:22:33') do
+          Timecop.freeze('2014-04-14 08:22:33') do
             item.save!
           end
         end

--- a/spec/models/kind_spec.rb
+++ b/spec/models/kind_spec.rb
@@ -5,10 +5,10 @@ describe Kind do
     @kind = Kind.new "Bummers", "Things we found that were upsetting"
   end
   it "has a name" do
-    @kind.name.should == "Bummers"
+    expect(@kind.name).to eq "Bummers"
   end
 
   it "has a subtitle" do
-    @kind.subtitle.should == "Things we found that were upsetting"
+    expect(@kind.subtitle).to eq "Things we found that were upsetting"
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 describe Post do
   describe 'associations' do
-    it { should belong_to(:standup) }
+    it { is_expected.to belong_to(:standup) }
 
-    it { should have_many(:items) }
-    it { should have_many(:public_items) }
+    it { is_expected.to have_many(:items) }
+    it { is_expected.to have_many(:public_items) }
   end
 
   describe "validations" do
-    it { should validate_presence_of(:standup) }
-    it { should validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:standup) }
+    it { is_expected.to validate_presence_of(:title) }
   end
 
   describe "#adopt_all_items" do
@@ -24,7 +24,7 @@ describe Post do
       post = create(:post, standup: standup)
       post.adopt_all_the_items
 
-      post.items.should == [unclaimed_item]
+      expect(post.items).to eq [unclaimed_item]
     end
 
     it "does not adopt bumped items" do
@@ -36,7 +36,7 @@ describe Post do
       post = create(:post, standup: standup)
       post.adopt_all_the_items
 
-      post.items.should == [unclaimed_item]
+      expect(post.items).to eq [unclaimed_item]
     end
 
     it "does not adopt items with a date after today" do
@@ -46,7 +46,7 @@ describe Post do
       post = create(:post, standup: standup)
       post.adopt_all_the_items
 
-      post.items.should == [item_for_today]
+      expect(post.items).to eq [item_for_today]
     end
 
     it "adopts items only for same standup" do
@@ -58,7 +58,7 @@ describe Post do
       post = create(:post, standup: standup)
       post.adopt_all_the_items
 
-      post.items.should == [unclaimed_item]
+      expect(post.items).to eq [unclaimed_item]
     end
   end
 
@@ -68,7 +68,7 @@ describe Post do
 
       it 'prepends the subject_prefix and date' do
         post = create(:post, standup: standup, title: "With Feeling", created_at: Time.parse("2012-06-02 12:00:00 -0700"))
-        post.title_for_email.should == "#{standup.subject_prefix} 06/02/12: With Feeling"
+        expect(post.title_for_email).to eq "#{standup.subject_prefix} 06/02/12: With Feeling"
       end
     end
 
@@ -77,7 +77,7 @@ describe Post do
 
       it 'prepends [Standup] and the date' do
         post = create(:post, standup: standup, title: "With Feeling", created_at: Time.parse("2012-06-02 12:00:00 -0700"))
-        post.title_for_email.should == "[Standup] 06/02/12: With Feeling"
+        expect(post.title_for_email).to eq "[Standup] 06/02/12: With Feeling"
       end
     end
   end
@@ -85,7 +85,7 @@ describe Post do
   describe '#title_for_blog' do
     it 'prepends the data' do
       post = create(:post, title: "With Feeling", created_at: Time.parse("2012-06-02 12:00:00 -0700"))
-      post.title_for_blog.should == "06/02/12: With Feeling"
+      expect(post.title_for_blog).to eq "06/02/12: With Feeling"
     end
   end
 
@@ -93,13 +93,13 @@ describe Post do
     it "sends an email" do
       post = create(:post, items: [create(:item)])
       post.deliver_email
-      ActionMailer::Base.deliveries.last.to.should == [post.standup.to_address]
+      expect(ActionMailer::Base.deliveries.last.to).to eq [post.standup.to_address]
     end
 
     it "raises an error if you send it twice" do
       post = create(:post, items: [create(:item)])
       post.deliver_email
-      ActionMailer::Base.deliveries.last.to.should == [post.standup.to_address]
+      expect(ActionMailer::Base.deliveries.last.to).to eq [post.standup.to_address]
       expect { post.deliver_email }.to raise_error("Duplicate Email")
     end
   end
@@ -109,7 +109,7 @@ describe Post do
       post = create(:post)
       items = [create(:item, created_at: Time.now), create(:item, created_at: 2.days.ago)]
       post.items = items
-      post.items_by_type['Help'].should == items.reverse
+      expect(post.items_by_type['Help']).to eq items.reverse
     end
 
     it "merges events without overriding today's event" do
@@ -117,67 +117,67 @@ describe Post do
       post.items = [create(:event, created_at: Time.now, standup_id: post.standup.id)]
 
       future_item = create(:event, created_at: Date.tomorrow, standup_id: post.standup.id)
-      post.items_by_type['Event'].should == post.items + [future_item]
+      expect(post.items_by_type['Event']).to eq post.items + [future_item]
     end
   end
 
   describe "#publishable_content?" do
     it "returns false when no content items and no events" do
       post = create(:post)
-      post.publishable_content?.should == false
+      expect(post.publishable_content?).to eq false
     end
 
     it "returns false when no public content items or public event" do
       post = create(:post, items: [create(:item, created_at: Time.now, public: false)])
       create(:event, date: 1.day.from_now.to_date, public: false)
-      post.publishable_content?.should == false
+      expect(post.publishable_content?).to eq false
     end
 
     it "returns true when there are public content items" do
       post = create(:post, items: [create(:item, created_at: Time.now, public: true)])
-      post.publishable_content?.should == true
+      expect(post.publishable_content?).to eq true
     end
 
     it "returns true when there are public events" do
       post = create(:post, items: [create(:item, created_at: Time.now, public: false)])
       create(:event, date: 1.day.from_now.to_date, public: true, standup: post.standup)
-      post.publishable_content?.should == true
+      expect(post.publishable_content?).to eq true
     end
   end
 
   describe "#emailable_content?" do
     it "returns false when no content items and no events" do
       post = create(:post)
-      post.emailable_content?.should == false
+      expect(post.emailable_content?).to eq false
     end
 
     it "returns true with a private content item" do
       post = create(:post, items: [create(:item, created_at: Time.now, public: false)])
-      post.emailable_content?.should == true
+      expect(post.emailable_content?).to eq true
     end
 
     it "returns true with a private event" do
       post = create(:post, items: [])
       create(:event, date: 1.day.from_now.to_date, public: false, standup: post.standup)
-      post.emailable_content?.should == true
+      expect(post.emailable_content?).to eq true
     end
 
     it "returns true when there are public content items" do
       post = create(:post, items: [create(:item, created_at: Time.now, public: true)])
-      post.emailable_content?.should == true
+      expect(post.emailable_content?).to eq true
     end
 
     it "returns true when there are public events" do
       post = create(:post, items: [])
       create(:event, date: 1.day.from_now.to_date, public: true, standup: post.standup)
-      post.emailable_content?.should == true
+      expect(post.emailable_content?).to eq true
     end
   end
 
   describe "#public_url" do
     it 'exists when blog service is defined and has a blog_post_id' do
       @fakeWordpress = double("wordpress service", :"minimally_configured?" => true, :"public_url" => 'http://example.com')
-      Rails.application.config.stub(:blogging_service) { @fakeWordpress }
+      allow(Rails.application.config).to receive(:blogging_service) { @fakeWordpress }
 
       post = Post.new
       post.blog_post_id = 'some-thing'
@@ -186,7 +186,7 @@ describe Post do
 
     it 'returns an empty string when blog service is not defined' do
       @fakeWordpress = double("wordpress service", :"minimally_configured?" => false)
-      Rails.application.config.stub(:blogging_service) { @fakeWordpress }
+      allow(Rails.application.config).to receive(:blogging_service) { @fakeWordpress }
 
       post = Post.new
       post.blog_post_id = 'some-thing'
@@ -195,7 +195,7 @@ describe Post do
 
     it 'returns an empty string when blog_post_id is not defined ' do
       @fakeWordpress = double("wordpress service", :"minimally_configured?" => true, :"public_url" => 'http://example.com')
-      Rails.application.config.stub(:blogging_service) { @fakeWordpress }
+      allow(Rails.application.config).to receive(:blogging_service) { @fakeWordpress }
 
       post = Post.new
       expect(post.public_url).to eq('')

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -40,8 +40,8 @@ describe Post do
     end
 
     it "does not adopt items with a date after today" do
-      item_for_today = create(:item, date: Date.today, standup: standup)
-      item_for_tomorrow = create(:item, date: Date.tomorrow, standup: standup)
+      item_for_today = create(:item, date: Time.zone.today, standup: standup)
+      item_for_tomorrow = create(:item, date: Time.zone.tomorrow, standup: standup)
 
       post = create(:post, standup: standup)
       post.adopt_all_the_items
@@ -116,7 +116,7 @@ describe Post do
       post = create(:post)
       post.items = [create(:event, created_at: Time.now, standup_id: post.standup.id)]
 
-      future_item = create(:event, created_at: Date.tomorrow, standup_id: post.standup.id)
+      future_item = create(:event, created_at: Time.zone.tomorrow, standup_id: post.standup.id)
       expect(post.items_by_type['Event']).to eq post.items + [future_item]
     end
   end

--- a/spec/models/standup_presenter_spec.rb
+++ b/spec/models/standup_presenter_spec.rb
@@ -11,12 +11,12 @@ describe StandupPresenter do
 
   context 'when standup object does not have a closing message' do
     it 'picks a closing message' do
-      allow(Date).to receive_message_chain(:today, :wday).and_return(4)
+      allow(Time).to receive_message_chain(:zone, :today, :wday).and_return(4)
       expect(StandupPresenter::STANDUP_CLOSINGS).to include(subject.closing_message)
     end
 
     it 'should remind us when its Floor Friday' do
-      allow(Date).to receive_message_chain(:today, :wday).and_return(5)
+      allow(Time).to receive_message_chain(:zone, :today, :wday).and_return(5)
       expect(subject.closing_message).to eq "STRETCH! It's Floor Friday!"
     end
   end

--- a/spec/models/standup_presenter_spec.rb
+++ b/spec/models/standup_presenter_spec.rb
@@ -37,7 +37,7 @@ describe StandupPresenter do
 
     context 'when the day is selected' do
       before do
-        Timecop.travel(Time.local(2013, 9, 2, 12, 0, 0)) #monday
+        Timecop.travel(Time.zone.local(2013, 9, 2, 12, 0, 0)) #monday
       end
 
       after do
@@ -62,7 +62,7 @@ describe StandupPresenter do
 
     context 'when the day is not selected' do
       before do
-        Timecop.travel(Time.local(2013, 9, 4, 12, 0, 0)) #wednesday
+        Timecop.travel(Time.zone.local(2013, 9, 4, 12, 0, 0)) #wednesday
       end
 
       after do

--- a/spec/models/standup_presenter_spec.rb
+++ b/spec/models/standup_presenter_spec.rb
@@ -6,18 +6,18 @@ describe StandupPresenter do
   subject { StandupPresenter.new(standup) }
 
   it 'delegates methods to standup' do
-    subject.foo.should == 'bar'
+    expect(subject.foo).to eq 'bar'
   end
 
   context 'when standup object does not have a closing message' do
     it 'picks a closing message' do
-      Date.stub_chain(:today, :wday).and_return(4)
-      StandupPresenter::STANDUP_CLOSINGS.should include(subject.closing_message)
+      allow(Date).to receive_message_chain(:today, :wday).and_return(4)
+      expect(StandupPresenter::STANDUP_CLOSINGS).to include(subject.closing_message)
     end
 
     it 'should remind us when its Floor Friday' do
-      Date.stub_chain(:today, :wday).and_return(5)
-      subject.closing_message.should == "STRETCH! It's Floor Friday!"
+      allow(Date).to receive_message_chain(:today, :wday).and_return(5)
+      expect(subject.closing_message).to eq "STRETCH! It's Floor Friday!"
     end
   end
 
@@ -25,7 +25,7 @@ describe StandupPresenter do
     let(:standup) { double(closing_message: 'Yay!') }
 
     it 'returns the standup closing message' do
-      subject.closing_message.should == 'Yay!'
+      expect(subject.closing_message).to eq 'Yay!'
     end
   end
 
@@ -46,7 +46,7 @@ describe StandupPresenter do
 
       context 'when the directory contains files' do
         it 'returns an image url from the list of image urls' do
-          image_urls.should include subject.closing_image
+          expect(image_urls).to include subject.closing_image
         end
 
         it 'does not return the same image 100 times in a row' do
@@ -55,7 +55,7 @@ describe StandupPresenter do
             images << subject.closing_image
           end
 
-          images.uniq.length.should == 2
+          expect(images.uniq.length).to eq 2
         end
       end
     end
@@ -70,7 +70,7 @@ describe StandupPresenter do
       end
 
       it 'returns nil' do
-        subject.closing_image.should be_nil
+        expect(subject.closing_image).to be_nil
       end
     end
   end

--- a/spec/models/standup_spec.rb
+++ b/spec/models/standup_spec.rb
@@ -2,35 +2,35 @@ require 'rails_helper'
 
 describe Standup do
   describe 'associations' do
-    it { should have_many(:items).dependent(:destroy) }
-    it { should have_many(:posts).dependent(:destroy) }
+    it { is_expected.to have_many(:items).dependent(:destroy) }
+    it { is_expected.to have_many(:posts).dependent(:destroy) }
   end
 
   describe 'validations' do
-    it { should validate_presence_of(:title) }
-    it { should validate_presence_of(:to_address) }
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:to_address) }
 
     it "should validate the format of the standup time" do
       standup = FactoryGirl.build(:standup)
-      standup.should be_valid
+      expect(standup).to be_valid
 
       standup.start_time_string = "9:00 am"
-      standup.should be_valid
+      expect(standup).to be_valid
 
       standup.start_time_string = "09:10 AM"
-      standup.should be_valid
+      expect(standup).to be_valid
 
       standup.start_time_string = "10:00"
-      standup.should_not be_valid
+      expect(standup).to_not be_valid
 
       standup.start_time_string = "23:00"
-      standup.should_not be_valid
+      expect(standup).to_not be_valid
     end
   end
 
   it 'has a closing message' do
     standup = FactoryGirl.create(:standup, closing_message: 'Yay')
-    standup.closing_message.should == 'Yay'
+    expect(standup.closing_message).to eq 'Yay'
   end
 
   describe "dates" do
@@ -49,13 +49,13 @@ describe Standup do
 
     describe "#date_today" do
       it "returns the date based on the time zone" do
-        @standup.date_today.should == @utc_yesterday
+        expect(@standup.date_today).to eq @utc_yesterday
       end
     end
 
     describe "#date_tomorrow" do
       it "returns the date based on the time zone" do
-        @standup.date_tomorrow.should == @utc_today
+        expect(@standup.date_tomorrow).to eq @utc_today
       end
     end
 
@@ -65,7 +65,7 @@ describe Standup do
           standup_beginning_of_day = @standup.time_zone.now.beginning_of_day
 
           @standup.start_time_string = "5:00pm"
-          @standup.next_standup_date.should == standup_beginning_of_day + 17.hours
+          expect(@standup.next_standup_date).to eq standup_beginning_of_day + 17.hours
         end
       end
 
@@ -74,7 +74,7 @@ describe Standup do
           standup_beginning_of_day = @standup.time_zone.now.beginning_of_day
 
           @standup.start_time_string = "8:00am"
-          @standup.next_standup_date.should == standup_beginning_of_day + 1.day + 8.hour
+          expect(@standup.next_standup_date).to eq standup_beginning_of_day + 1.day + 8.hour
         end
       end
     end
@@ -97,6 +97,6 @@ describe Standup do
 
   it 'serializes the image_days array for storage in the db' do
     standup = create(:standup, image_days: ['mon', 'tue'])
-    standup.image_days.should == ['mon', 'tue']
+    expect(standup.image_days).to eq ['mon', 'tue']
   end
 end

--- a/spec/models/wordpress_service_spec.rb
+++ b/spec/models/wordpress_service_spec.rb
@@ -9,9 +9,9 @@ describe WordpressService do
 
     it "calls the connection with the attributes for the post" do
       connection = double("mock_connection")
-      subject.should_receive(:connection).and_return(connection)
+      expect(subject).to receive(:connection).and_return(connection)
 
-      connection.should_receive(:call).with(
+      expect(connection).to receive(:call).with(
         'metaWeblog.newPost',
         1,
         "user",
@@ -21,7 +21,7 @@ describe WordpressService do
 
       blog_post = double("blog post", post_hash: {post: :hash})
 
-      subject.send!(blog_post).should == "mocked call"
+      expect(subject.send!(blog_post)).to eq "mocked call"
     end
   end
 
@@ -34,27 +34,27 @@ describe WordpressService do
     end
 
     it "returns true when all the minimally necessary config is set" do
-      subject.minimally_configured?.should == true
+      expect(subject.minimally_configured?).to eq true
     end
 
     it "returns false when the host is missing" do
       subject.host = nil
-      subject.minimally_configured?.should == false
+      expect(subject.minimally_configured?).to eq false
     end
 
     it "returns false when the endpoint path is missing" do
       subject.endpoint_path = nil
-      subject.minimally_configured?.should == false
+      expect(subject.minimally_configured?).to eq false
     end
 
     it "returns false when the wordpress username is missing" do
       subject.wordpress_username = nil
-      subject.minimally_configured?.should == false
+      expect(subject.minimally_configured?).to eq false
     end
 
     it "returns false when the wordpress password is missing" do
       subject.wordpress_password = nil
-      subject.minimally_configured?.should == false
+      expect(subject.minimally_configured?).to eq false
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,6 @@ ENV["RAILS_ENV"] ||= 'test'
 
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
 require 'capybara/rails'
 require 'capybara/rspec'
 require 'codeclimate-test-reporter'

--- a/spec/routing/item_routing_spec.rb
+++ b/spec/routing/item_routing_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 describe ItemsController do
   it "routes presentation" do
-    get("standups/2/items/presentation").should route_to("items#presentation", standup_id: '2')
+    expect(get("standups/2/items/presentation")).to route_to("items#presentation", standup_id: '2')
   end
 
   it "routes new" do
-    get("standups/1/items/new").should route_to("items#new", standup_id: '1')
+    expect(get("standups/1/items/new")).to route_to("items#new", standup_id: '1')
   end
 
   it "routes creates" do
-    post("items").should route_to("items#create")
+    expect(post("items")).to route_to("items#create")
   end
 end

--- a/spec/routing/post_routing_spec.rb
+++ b/spec/routing/post_routing_spec.rb
@@ -2,18 +2,18 @@ require 'rails_helper'
 
 describe PostsController do
   it "routes send_email" do
-    put("posts/1/send_email").should route_to("posts#send_email", id: '1')
+    expect(put("posts/1/send_email")).to route_to("posts#send_email", id: '1')
   end
 
   it "routes to post_to_blog" do
-    put("posts/1/post_to_blog").should route_to("posts#post_to_blog", id: '1')
+    expect(put("posts/1/post_to_blog")).to route_to("posts#post_to_blog", id: '1')
   end
 
   it "routes to archive" do
-    put("posts/1/archive").should route_to("posts#archive", id: "1")
+    expect(put("posts/1/archive")).to route_to("posts#archive", id: "1")
   end
 
   it "routes to archived" do
-    get('standups/2/posts/archived').should route_to("posts#archived", standup_id: '2')
+    expect(get('standups/2/posts/archived')).to route_to("posts#archived", standup_id: '2')
   end
 end

--- a/spec/routing/session_routing_spec.rb
+++ b/spec/routing/session_routing_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 describe SessionsController do
   it 'routes to logout' do
-    get('/logout').should route_to('sessions#destroy')
+    expect(get('/logout')).to route_to('sessions#destroy')
   end
 
   it 'routes to create' do
-    post('/auth/saml/callback').should route_to(:controller => 'sessions', :action => 'create')
+    expect(post('/auth/saml/callback')).to route_to(:controller => 'sessions', :action => 'create')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,8 +9,8 @@ RSpec.configure do |config|
   end
 
   config.before(:all, type: :feature) do
-    current_session = Capybara.current_session
-    current_session.driver.resize_window(2000, 2000)
+    current_window = Capybara.current_window
+    current_window.resize_to(2000, 2000)
   end
 
   config.after(:each) do

--- a/spec/support/capybara_webkit.rb
+++ b/spec/support/capybara_webkit.rb
@@ -1,0 +1,4 @@
+Capybara::Webkit.configure do |config|
+  # Silently return an empty 200 response for any requests to unknown URLs.
+  config.block_unknown_urls
+end

--- a/spec/support/mock_auth.rb
+++ b/spec/support/mock_auth.rb
@@ -1,5 +1,5 @@
 module MockAuth
   def login
-    ApplicationController.any_instance.stub(:session).and_return({logged_in: true, username: nil})
+    allow_any_instance_of(ApplicationController).to receive(:session).and_return({logged_in: true, username: nil})
   end
 end

--- a/spec/support/shared_examples/an_action_occurring_within_the_standups_timezone.rb
+++ b/spec/support/shared_examples/an_action_occurring_within_the_standups_timezone.rb
@@ -1,8 +1,13 @@
 shared_examples_for "an action occurring within the standup's timezone" do
   let(:time_zone_name) { double(:time_zone_name) }
+  let(:standup) { double(:standup, time_zone_name: time_zone_name).as_null_object }
+
+  before do
+    allow(Standup).to receive(:find_by).and_return(standup)
+    allow(Standup).to receive(:find).and_return(standup)
+  end
 
   specify do
-    expect(Standup).to receive(:find_by).and_return(double(:standup, time_zone_name: time_zone_name))
     expect(Time).to receive(:use_zone).with(time_zone_name)
   end
 end

--- a/spec/support/shared_examples/an_action_occurring_within_the_standups_timezone.rb
+++ b/spec/support/shared_examples/an_action_occurring_within_the_standups_timezone.rb
@@ -1,0 +1,8 @@
+shared_examples_for "an action occurring within the standup's timezone" do
+  let(:time_zone_name) { double(:time_zone_name) }
+
+  specify do
+    expect(Standup).to receive(:find_by).and_return(double(:standup, time_zone_name: time_zone_name))
+    expect(Time).to receive(:use_zone).with(time_zone_name)
+  end
+end


### PR DESCRIPTION
Whiteboard tests do not run in weird timezones like +11 GMT (Sydney).

Referencing this: http://danilenko.org/2012/7/6/rails_timezones/

It would seem using `Time.zone.local` instead of `Time.local` is the way to go