### PR TITLE
Display last time e-mail was sent on items index

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,7 @@ class ItemsController < ApplicationController
   def index
     events = Item.events_on_or_after(Time.zone.today, @standup)
     @items = @standup.items.orphans.merge(events)
+
     respond_with(@items)
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,21 @@ class PostsController < ApplicationController
     @post = @standup.posts.build(params[:post])
     if @post.save
       @post.adopt_all_the_items
-      redirect_to edit_post_path(@post)
+
+      if @standup.one_click_post?
+        begin
+          @post.deliver_email
+          @post.archived = true
+          @post.save!
+          flash[:notice] = "Successfully sent Standup email!"
+          redirect_to @standup
+        rescue
+          flash[:error] = "Failed to send email. Please try again."
+          redirect_to edit_post_path(@post)
+        end
+      else
+        redirect_to edit_post_path(@post)
+      end
     else
       flash[:error] = "Unable to create post"
       redirect_to @standup

--- a/app/models/standup.rb
+++ b/app/models/standup.rb
@@ -41,6 +41,10 @@ class Standup < ActiveRecord::Base
     standup_time_today < time_zone.now
   end
 
+  def last_email_time
+    posts.where.not(sent_at: nil).order(:sent_at).reverse_order.limit(1).first.try(:sent_at)
+  end
+
   private
 
   def standup_time_today

--- a/app/models/standup.rb
+++ b/app/models/standup.rb
@@ -3,7 +3,7 @@ require "ipaddr"
 class Standup < ActiveRecord::Base
   TIME_FORMAT = /(\d{1,2}):(\d{2})\s*(am|pm)/i
 
-  attr_accessible :title, :to_address, :subject_prefix, :closing_message, :time_zone_name, :start_time_string, :image_urls, :image_days
+  attr_accessible :title, :to_address, :subject_prefix, :closing_message, :time_zone_name, :start_time_string, :image_urls, :image_days, :one_click_post
   serialize :image_days
 
   has_many :items, dependent: :destroy

--- a/app/models/standup_presenter.rb
+++ b/app/models/standup_presenter.rb
@@ -50,6 +50,10 @@ class StandupPresenter < SimpleDelegator
     end
   end
 
+  def last_email_time_message
+    @standup.last_email_time.try(:strftime, "Last standup email sent: %-l:%M%p %A %b %-d, %Y")
+  end
+
   def closing_image
     return nil unless @standup.image_days.include? @standup.date_today.strftime("%a")
     @standup.image_urls.split("\n").reject(&:blank?).sample

--- a/app/models/standup_presenter.rb
+++ b/app/models/standup_presenter.rb
@@ -34,6 +34,22 @@ class StandupPresenter < SimpleDelegator
     end
   end
 
+  def create_post_sender_field_placeholder
+    if @standup.one_click_post?
+      "Standup host(s)"
+    else
+      "Blogger Name(s)"
+    end
+  end
+
+  def create_post_subject_field_placeholder
+    if @standup.one_click_post?
+      "Email subject"
+    else
+      "Post Title (eg: Best Standup Ever)"
+    end
+  end
+
   def closing_image
     return nil unless @standup.image_days.include? @standup.date_today.strftime("%a")
     @standup.image_urls.split("\n").reject(&:blank?).sample

--- a/app/models/standup_presenter.rb
+++ b/app/models/standup_presenter.rb
@@ -18,6 +18,22 @@ class StandupPresenter < SimpleDelegator
     STANDUP_CLOSINGS.sample
   end
 
+  def create_post_button_text
+    if @standup.one_click_post?
+      "Send Email"
+    else
+      "Create Post"
+    end
+  end
+
+  def create_post_confirm_message
+    if @standup.one_click_post?
+      "You are about to send today's stand up email. Continue?"
+    else
+      "This will clear the board and create a new one for tomorrow, you can always get back to this post under the \"Posts\" menu in the header. Continue?"
+    end
+  end
+
   def closing_image
     return nil unless @standup.image_days.include? @standup.date_today.strftime("%a")
     @standup.image_urls.split("\n").reject(&:blank?).sample

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,6 +6,7 @@
   <div class='bottom border-top'>
     <div class='navbar-inner'>
       <%= link_to 'Presentation', presentation_standup_items_path(@standup), class: 'btn btn-success navbar-btn' %>
+      <span class="badge alert-info"><%= @standup.last_email_time_message %></span>
       <%= form_tag "/standups/#{@standup.id}/posts", method: 'post', class: 'navbar-form pull-right' do %>
           <%= text_field_tag 'post[from]', nil, placeholder: @standup.create_post_sender_field_placeholder %>
           <%= text_field_tag 'post[title]', nil, placeholder: @standup.create_post_subject_field_placeholder, class: 'wide-input' %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -7,8 +7,8 @@
     <div class='navbar-inner'>
       <%= link_to 'Presentation', presentation_standup_items_path(@standup), class: 'btn btn-success navbar-btn' %>
       <%= form_tag "/standups/#{@standup.id}/posts", method: 'post', class: 'navbar-form pull-right' do %>
-          <%= text_field_tag 'post[from]', nil, placeholder: 'Standup host(s)' %>
-          <%= text_field_tag 'post[title]', nil, placeholder: 'Email subject', class: 'wide-input' %>
+          <%= text_field_tag 'post[from]', nil, placeholder: @standup.create_post_sender_field_placeholder %>
+          <%= text_field_tag 'post[title]', nil, placeholder: @standup.create_post_subject_field_placeholder, class: 'wide-input' %>
           <%= submit_tag @standup.create_post_button_text,
                          data: {confirm: @standup.create_post_confirm_message },
                          id: 'create-post',

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -7,10 +7,10 @@
     <div class='navbar-inner'>
       <%= link_to 'Presentation', presentation_standup_items_path(@standup), class: 'btn btn-success navbar-btn' %>
       <%= form_tag "/standups/#{@standup.id}/posts", method: 'post', class: 'navbar-form pull-right' do %>
-          <%= text_field_tag 'post[from]', nil, placeholder: 'Blogger Name(s)' %>
-          <%= text_field_tag 'post[title]', nil, placeholder: 'Post Title (eg: Best Standup Ever)', class: 'wide-input' %>
-          <%= submit_tag 'Create Post',
-                         data: {confirm: 'This will clear the board and create a new one for tomorrow, you can always get back to this post under the "Posts" menu in the header. Continue?'},
+          <%= text_field_tag 'post[from]', nil, placeholder: 'Standup host(s)' %>
+          <%= text_field_tag 'post[title]', nil, placeholder: 'Email subject', class: 'wide-input' %>
+          <%= submit_tag @standup.create_post_button_text,
+                         data: {confirm: @standup.create_post_confirm_message },
                          id: 'create-post',
                          class: 'btn btn-warning'
           %>

--- a/app/views/standups/_form.html.erb
+++ b/app/views/standups/_form.html.erb
@@ -57,6 +57,13 @@
       </div>
     </div>
 
+    <div class='one_click_post'>
+      <%= form.label :one_click_post, 'Post e-mail & archive in 1-click?', class: 'control-label col-sm-2' %>
+      <div class="controls col-sm-10">
+        <%= form.check_box :one_click_post %>
+      </div>
+    </div>
+
     <div class='form-group'>
       <div class="controls col-sm-10">
         <%= form.submit class: 'btn btn-primary' %>

--- a/db/migrate/20160107161453_add_one_click_post_to_standups.rb
+++ b/db/migrate/20160107161453_add_one_click_post_to_standups.rb
@@ -1,0 +1,5 @@
+class AddOneClickPostToStandups < ActiveRecord::Migration
+  def change
+    add_column :standups, :one_click_post, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131017003125) do
+ActiveRecord::Schema.define(version: 20160107161453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 20131017003125) do
     t.string   "start_time_string",   default: "9:06am"
     t.text     "image_urls"
     t.string   "image_days"
+    t.boolean  "one_click_post"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20131017003125) do
     t.datetime "updated_at"
     t.string   "closing_message"
     t.string   "time_zone_name",      default: "Eastern Time (US & Canada)", null: false
+    t.text     "ip_addresses_string"
     t.string   "start_time_string",   default: "9:06am"
     t.text     "image_urls"
     t.string   "image_days"

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -106,7 +106,7 @@ describe ItemsController do
       help = create(:item, kind: "Help", standup: standup)
       new_face = create(:new_face, standup: standup)
       interesting = create(:item, kind: "Interesting", standup: standup)
-      posted_item = create(:item, post: post, standup: standup)
+      create(:item, post: post, standup: standup)
 
       get :index, params
       expect(assigns[:items]['New face']).to eq [ new_face ]

--- a/spec/features/email_and_archive_spec.rb
+++ b/spec/features/email_and_archive_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+describe "creating a standup post from the whiteboard", js: true do
+  let!(:item) { FactoryGirl.create(:item, kind: 'Interesting', title: "So so interesting") }
+
+  before do
+    login
+  end
+
+  def verify_on_items_page
+    expect(page).to have_css('h2.title', text: 'NEW FACES')
+    expect(page).to have_css('h2.title', text: 'HELPS')
+    expect(page).to have_css('h2.title', text: 'INTERESTINGS')
+    expect(page).to have_css('h2.title', text: 'EVENTS')
+  end
+
+  context "when standup is configured for 1-click email & archive" do
+    let!(:standup) { FactoryGirl.create(:standup, title: 'Camelot', subject_prefix: "[Standup][CO]", one_click_post: true, items: [item]) }
+
+    before do
+      visit '/'
+      click_link(standup.title)
+
+      expect(page).to have_content("So so interesting")
+
+      fill_in "Blogger Name(s)", with: "Me"
+      fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
+
+      page.evaluate_script('window.confirm = function() { return true; }')
+      click_on "Create Post"
+    end
+
+    it "emails and archives the e-mail in 1 step when the user creates the post" do
+      verify_on_items_page
+
+      expect(page).to have_content('Successfully sent Standup email!')
+      expect(page).to_not have_content('So so interesting')
+    end
+  end
+
+  context "when standup is NOT configured for 1-click email & archive" do
+    let!(:standup) { FactoryGirl.create(:standup, title: 'Camelot', subject_prefix: "[Standup][CO]", one_click_post: false, items: [item]) }
+
+    before do
+      visit '/'
+      click_link(standup.title)
+
+      expect(page).to have_content("So so interesting")
+
+      fill_in "Blogger Name(s)", with: "Me"
+      fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
+
+      page.evaluate_script('window.confirm = function() { return true; }')
+      click_on "Create Post"
+    end
+
+    it "requires the user to individually review, send e-mail and then archive" do
+      expect(page).to have_content("So so interesting")
+
+      page.evaluate_script('window.confirm = function() { return true; }')
+      click_on "Send Email"
+
+      expect(page).to have_content("This email was sent at")
+      expect(page).to_not have_css('a.btn', text: 'Send Email')
+
+      page.evaluate_script('window.confirm = function() { return true; }')
+      click_on "Archive Post"
+
+      verify_on_items_page
+      expect(page).to_not have_content('So so interesting')
+    end
+  end
+
+end

--- a/spec/features/email_and_archive_spec.rb
+++ b/spec/features/email_and_archive_spec.rb
@@ -26,6 +26,7 @@ describe "creating a standup post from the whiteboard", js: true do
       fill_in "Standup host(s)", with: "Me"
       fill_in "Email subject", with: "empty post"
 
+      expect(page).to_not have_content("Last standup email sent: ")
       @message = accept_confirm do
         click_on "Send Email"
       end
@@ -37,6 +38,8 @@ describe "creating a standup post from the whiteboard", js: true do
       expect(@message).to eq("You are about to send today's stand up email. Continue?")
       expect(page).to have_content('Successfully sent Standup email!')
       expect(page).to_not have_content('So so interesting')
+
+      expect(page).to have_content("Last standup email sent: ")
     end
   end
 
@@ -60,6 +63,7 @@ describe "creating a standup post from the whiteboard", js: true do
     it "requires the user to individually review, send e-mail and then archive" do
       expect(@message).to eq('This will clear the board and create a new one for tomorrow, you can always get back to this post under the "Posts" menu in the header. Continue?')
       expect(page).to have_content("So so interesting")
+      expect(page).to_not have_content("Last standup email sent: ")
 
       accept_confirm do
         click_on "Send Email"
@@ -72,6 +76,8 @@ describe "creating a standup post from the whiteboard", js: true do
 
       verify_on_items_page
       expect(page).to_not have_content('So so interesting')
+
+      expect(page).to have_content("Last standup email sent: ")
     end
   end
 

--- a/spec/features/email_and_archive_spec.rb
+++ b/spec/features/email_and_archive_spec.rb
@@ -23,16 +23,18 @@ describe "creating a standup post from the whiteboard", js: true do
 
       expect(page).to have_content("So so interesting")
 
-      fill_in "Blogger Name(s)", with: "Me"
-      fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
+      fill_in "Standup host(s)", with: "Me"
+      fill_in "Email subject", with: "empty post"
 
-      page.evaluate_script('window.confirm = function() { return true; }')
-      click_on "Create Post"
+      @message = accept_confirm do
+        click_on "Send Email"
+      end
     end
 
     it "emails and archives the e-mail in 1 step when the user creates the post" do
       verify_on_items_page
 
+      expect(@message).to eq("You are about to send today's stand up email. Continue?")
       expect(page).to have_content('Successfully sent Standup email!')
       expect(page).to_not have_content('So so interesting')
     end
@@ -47,23 +49,25 @@ describe "creating a standup post from the whiteboard", js: true do
 
       expect(page).to have_content("So so interesting")
 
-      fill_in "Blogger Name(s)", with: "Me"
-      fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
+      fill_in "Standup host(s)", with: "Me"
+      fill_in "Email subject", with: "empty post"
 
-      page.evaluate_script('window.confirm = function() { return true; }')
-      click_on "Create Post"
+      @message = accept_confirm do
+        click_on "Create Post"
+      end
     end
 
     it "requires the user to individually review, send e-mail and then archive" do
+      expect(@message).to eq('This will clear the board and create a new one for tomorrow, you can always get back to this post under the "Posts" menu in the header. Continue?')
       expect(page).to have_content("So so interesting")
 
-      page.evaluate_script('window.confirm = function() { return true; }')
-      click_on "Send Email"
+      accept_confirm do
+        click_on "Send Email"
+      end
 
       expect(page).to have_content("This email was sent at")
       expect(page).to_not have_css('a.btn', text: 'Send Email')
 
-      page.evaluate_script('window.confirm = function() { return true; }')
       click_on "Archive Post"
 
       verify_on_items_page

--- a/spec/features/email_and_archive_spec.rb
+++ b/spec/features/email_and_archive_spec.rb
@@ -49,8 +49,8 @@ describe "creating a standup post from the whiteboard", js: true do
 
       expect(page).to have_content("So so interesting")
 
-      fill_in "Standup host(s)", with: "Me"
-      fill_in "Email subject", with: "empty post"
+      fill_in "Blogger Name(s)", with: "Me"
+      fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
 
       @message = accept_confirm do
         click_on "Create Post"

--- a/spec/features/publishing_spec.rb
+++ b/spec/features/publishing_spec.rb
@@ -14,8 +14,8 @@ describe "publishing", js: true do
     expect_any_instance_of(WordpressService).to_not receive(:send!)
     click_link(standup.title)
 
-    fill_in "Standup host(s)", with: "Me"
-    fill_in "Email subject", with: "empty post"
+    fill_in "Blogger Name(s)", with: "Me"
+    fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
 
     accept_confirm do
       click_on "Create Post"
@@ -57,8 +57,8 @@ describe "publishing", js: true do
     click_on 'Post to Blog'
     click_button 'Create Item'
 
-    fill_in "Standup host(s)", with: "Me"
-    fill_in "Email subject", with: "empty post"
+    fill_in "Blogger Name(s)", with: "Me"
+    fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
 
     accept_confirm do
       click_on "Create Post"
@@ -86,8 +86,8 @@ describe "publishing", js: true do
     click_on 'Post to Blog'
     click_button 'Create Item'
 
-    fill_in "Standup host(s)", with: "Me"
-    fill_in "Email subject", with: "empty post"
+    fill_in "Blogger Name(s)", with: "Me"
+    fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
 
     accept_confirm do
       click_on "Create Post"

--- a/spec/features/publishing_spec.rb
+++ b/spec/features/publishing_spec.rb
@@ -17,8 +17,9 @@ describe "publishing", js: true do
     fill_in "Standup host(s)", with: "Me"
     fill_in "Email subject", with: "empty post"
 
-    page.evaluate_script('window.confirm = function() { return true; }')
-    click_on "Create Post"
+    accept_confirm do
+      click_on "Create Post"
+    end
 
     expect(page).to have_content("Please update these items with any new information from standup:")
 
@@ -59,8 +60,9 @@ describe "publishing", js: true do
     fill_in "Standup host(s)", with: "Me"
     fill_in "Email subject", with: "empty post"
 
-    page.evaluate_script('window.confirm = function() { return true; }')
-    click_on "Create Post"
+    accept_confirm do
+      click_on "Create Post"
+    end
 
     click_on 'Post Blog Entry'
 
@@ -87,8 +89,9 @@ describe "publishing", js: true do
     fill_in "Standup host(s)", with: "Me"
     fill_in "Email subject", with: "empty post"
 
-    page.evaluate_script('window.confirm = function() { return true; }')
-    click_on "Create Post"
+    accept_confirm do
+      click_on "Create Post"
+    end
 
     click_on 'Post Blog Entry'
 

--- a/spec/features/publishing_spec.rb
+++ b/spec/features/publishing_spec.rb
@@ -14,8 +14,8 @@ describe "publishing", js: true do
     expect_any_instance_of(WordpressService).to_not receive(:send!)
     click_link(standup.title)
 
-    fill_in "Blogger Name(s)", with: "Me"
-    fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
+    fill_in "Standup host(s)", with: "Me"
+    fill_in "Email subject", with: "empty post"
 
     page.evaluate_script('window.confirm = function() { return true; }')
     click_on "Create Post"
@@ -56,8 +56,8 @@ describe "publishing", js: true do
     click_on 'Post to Blog'
     click_button 'Create Item'
 
-    fill_in "Blogger Name(s)", with: "Me"
-    fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
+    fill_in "Standup host(s)", with: "Me"
+    fill_in "Email subject", with: "empty post"
 
     page.evaluate_script('window.confirm = function() { return true; }')
     click_on "Create Post"
@@ -84,8 +84,8 @@ describe "publishing", js: true do
     click_on 'Post to Blog'
     click_button 'Create Item'
 
-    fill_in "Blogger Name(s)", with: "Me"
-    fill_in "Post Title (eg: Best Standup Ever)", with: "empty post"
+    fill_in "Standup host(s)", with: "Me"
+    fill_in "Email subject", with: "empty post"
 
     page.evaluate_script('window.confirm = function() { return true; }')
     click_on "Create Post"

--- a/spec/features/standups_spec.rb
+++ b/spec/features/standups_spec.rb
@@ -16,6 +16,7 @@ describe "standups", :js do
     fill_in 'standup_closing_message', with: "Woohoo"
     fill_in 'standup_start_time_string', with: '10:00am'
     fill_in 'standup_image_urls', with: 'http://example.com/bar.png'
+    check 'standup_one_click_post'
     click_button 'Create Standup'
 
     click_link('All Standups')
@@ -41,6 +42,7 @@ describe "standups", :js do
     expect(page).to have_css('input[value="all@pivotallabs.com"]')
     expect(page).to have_css('input[value="Woohoo"]')
     expect(page).to have_css('option[value="Mountain Time (US & Canada)"][selected]')
+    expect(page).to have_css('input[name="standup[one_click_post]"][checked="checked"]')
     expect(page).to have_css('input[value="10:00am"]')
   end
 

--- a/spec/models/standup_presenter_spec.rb
+++ b/spec/models/standup_presenter_spec.rb
@@ -41,6 +41,14 @@ describe StandupPresenter do
     it "returns the create post button text for the multi-step post flow" do
       expect(subject.create_post_button_text).to eq "Create Post"
     end
+
+    it "returns the create post sender placeholder" do
+      expect(subject.create_post_sender_field_placeholder).to eq("Blogger Name(s)")
+    end
+
+    it "returns the crete post subject placeholder" do
+      expect(subject.create_post_subject_field_placeholder).to eq("Post Title (eg: Best Standup Ever)")
+    end
   end
 
   context "when standup has one click post enabled" do
@@ -54,6 +62,14 @@ describe StandupPresenter do
 
     it "returns the create post button text for the 1-click flow" do
       expect(subject.create_post_button_text).to eq "Send Email"
+    end
+
+    it "returns the create post sender placeholder" do
+      expect(subject.create_post_sender_field_placeholder).to eq("Standup host(s)")
+    end
+
+    it "returns the crete post subject placeholder" do
+      expect(subject.create_post_subject_field_placeholder).to eq("Email subject")
     end
   end
 

--- a/spec/models/standup_presenter_spec.rb
+++ b/spec/models/standup_presenter_spec.rb
@@ -29,6 +29,36 @@ describe StandupPresenter do
     end
   end
 
+  context "when the standup has posts that have been e-mailed" do
+    before do
+      allow(standup).to receive(:last_email_time).and_return(Time.local(2001, 01, 01, 12, 00))
+    end
+
+    it "returns the last email time message" do
+      expect(subject.last_email_time_message).to eq("Last standup email sent: 12:00PM Monday Jan 1, 2001")
+    end
+  end
+
+  context "when the standup DOES NOT have posts that have been e-mailed" do
+    before do
+      allow(standup).to receive(:last_email_time).and_return(nil)
+    end
+
+    it "does not return a last email time message" do
+      expect(subject.last_email_time_message).to be_nil
+    end
+  end
+
+  context "when the standup DOES NOT have posts" do
+    before do
+      allow(standup).to receive(:last_email_time).and_return(nil)
+    end
+
+    it "does not return a last email time message" do
+      expect(subject.last_email_time_message).to be_nil
+    end
+  end
+
   context "when standup does NOT have one click post enabled" do
     before do
       allow(standup).to receive(:one_click_post?).and_return(false)

--- a/spec/models/standup_presenter_spec.rb
+++ b/spec/models/standup_presenter_spec.rb
@@ -29,6 +29,34 @@ describe StandupPresenter do
     end
   end
 
+  context "when standup does NOT have one click post enabled" do
+    before do
+      allow(standup).to receive(:one_click_post?).and_return(false)
+    end
+
+    it "returns the create post confirmation message for the multi-step post flow" do
+      expect(subject.create_post_confirm_message).to eq "This will clear the board and create a new one for tomorrow, you can always get back to this post under the \"Posts\" menu in the header. Continue?"
+    end
+
+    it "returns the create post button text for the multi-step post flow" do
+      expect(subject.create_post_button_text).to eq "Create Post"
+    end
+  end
+
+  context "when standup has one click post enabled" do
+    before do
+      allow(standup).to receive(:one_click_post?).and_return(true)
+    end
+
+    it "returns the create post confirmation message for the 1-click flow" do
+      expect(subject.create_post_confirm_message).to eq "You are about to send today's stand up email. Continue?"
+    end
+
+    it "returns the create post button text for the 1-click flow" do
+      expect(subject.create_post_button_text).to eq "Send Email"
+    end
+  end
+
   describe '#closing_image' do
     let(:image_urls) {
       ['http://example.com/bar.png', 'http://example.com/baz.png']

--- a/spec/models/standup_spec.rb
+++ b/spec/models/standup_spec.rb
@@ -96,7 +96,8 @@ describe Standup do
           time_zone_name: "Mountain Time (US & Canada)",
           start_time_string: "9:00am",
           image_urls: 'http://example.com/bar.png',
-          image_days: '["M"]'
+          image_days: '["M"]',
+          one_click_post: true
       )
     }.to_not raise_exception
   end

--- a/spec/models/standup_spec.rb
+++ b/spec/models/standup_spec.rb
@@ -106,4 +106,29 @@ describe Standup do
     standup = create(:standup, image_days: ['mon', 'tue'])
     expect(standup.image_days).to eq ['mon', 'tue']
   end
+
+  describe "#last_email_time" do
+    context "when there are no posts" do
+      let (:standup_with_no_posts) { create(:standup) }
+
+      it "is nil" do
+        expect(standup_with_no_posts.last_email_time).to be_nil
+      end
+    end
+
+    context "when there are posts" do
+      let (:last_email_time) { Time.local(2016, 1, 1, 19, 42) }
+      let (:last_emailed_post) { create(:post, sent_at: last_email_time) }
+      let (:standup_with_posts) { create(:standup, posts: [
+        create(:post, sent_at: last_email_time - 1),
+        last_emailed_post,
+        create(:post, sent_at: last_email_time - 1),
+        create(:post, sent_at: nil)
+      ])}
+
+      it "is the time the most recently emailed post was emailed" do
+        expect(standup_with_posts.last_email_time).to eq(last_email_time)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Note that this change adds on to tests added in PR #84. It shows the last time an e-mail was sent for the current standup on the items index page. This way, a host/co-host can easily see whether or not someone has already sent the e-mail for today's standup.