### PR TITLE
use default short date where appropriate

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
 
   def format_title(item)
     if item.date?
-      "#{item.date.strftime("%A(%m/%d)")}: #{item.title}"
+      "#{item.date.strftime("%A(%b %d)")}: #{item.title}"
     else
       item.title
     end
@@ -33,7 +33,7 @@ module ApplicationHelper
 
   def date_label(item)
     if item.date.present? && (item.kind == "Event" || item.date > Time.zone.today)
-      return item.date.strftime("%m/%d") + ": " if is_item_after_this_week(item)
+      return l(item.date, format: :short) + ": " if is_item_after_this_week(item)
       Date::DAYNAMES[item.date.wday].to_s + ": "
     end
   end

--- a/app/views/items/presentation.html.erb
+++ b/app/views/items/presentation.html.erb
@@ -1,7 +1,7 @@
   <section class="slide">
     <h1>
       Standup<br/>
-      <span><%= @standup.date_today.strftime("%m/%d/%y") %></span>
+      <span><%= l(@standup.date_today, format: :short) %></span>
 
       <div class="countdown">
         <% if @standup.finished_today %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -33,7 +33,7 @@ describe ApplicationHelper do
 
     context "the item is an event" do
       let(:item) { Item.new(kind: "Interesting", title: "Not Interesting", date: Time.zone.tomorrow) }
-      it { is_expected.to eq "#{item.date.strftime("%A(%m/%d)")}: #{item.title}" }
+      it { is_expected.to eq "#{item.date.strftime("%A(%b %d)")}: #{item.title}" }
     end
 
     context "the item is not an event" do
@@ -44,7 +44,7 @@ describe ApplicationHelper do
 
       context "the item does have a date" do
         let(:item) { Item.new(kind: "Interesting", title: "Not Interesting", date: Time.zone.tomorrow) }
-        it { is_expected.to eq "#{item.date.strftime("%A(%m/%d)")}: #{item.title}" }
+        it { is_expected.to eq "#{item.date.strftime("%A(%b %d)")}: #{item.title}" }
       end
     end
   end
@@ -107,7 +107,7 @@ describe ApplicationHelper do
 
           it "displays the date rather than the day name" do
             label = helper.date_label(item)
-            expect(label).to eq "11/22: "
+            expect(label).to eq "Nov 22: "
           end
         end
       end


### PR DESCRIPTION
this potentially resolves #86 - if people are happy with the using the "Feb 01" format.

I think it's a good compromise, as we don't have to store standup date formats explicitly this way - and the dates make more sense to those of us using non american date formats.
