### PR TITLE
updated pipelines to do a blue-green deployment and add acceptance tests

### DIFF
--- a/concourse/tasks/acceptance/acceptance.sh
+++ b/concourse/tasks/acceptance/acceptance.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e -x
+
+pushd acceptance-tests
+    export WHITEBOARD_ENDPOINT=https://$TEMP_WHITEBOARD_HOSTNAME.$CF_DOMAIN
+    echo $WHITEBOARD_ENDPOINT
+    ./gradlew clean acceptanceTest
+popd

--- a/concourse/tasks/acceptance/acceptance.yml
+++ b/concourse/tasks/acceptance/acceptance.yml
@@ -1,0 +1,14 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: openjdk
+    tag: jdk
+
+inputs:
+  - name: whiteboard
+  - name: acceptance-tests
+
+run:
+  path: ./whiteboard/concourse/tasks/acceptance/acceptance.sh

--- a/concourse/tasks/deploy-maintenance/deploy-maintenance.sh
+++ b/concourse/tasks/deploy-maintenance/deploy-maintenance.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e -x
+
+start-maintenance ()
+{
+    appName=$1
+    domain=$2
+    hostname=$3
+
+    cf map-route maintenance-mode ${domain} -n ${hostname}
+    cf unmap-route ${appName} ${domain} -n ${hostname}
+}
+
+# get CF CLI
+wget -q -O cf-cli.deb https://cli.run.pivotal.io/stable?release=debian64
+sudo dpkg -i cf-cli.deb
+cf login -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE -a $CF_API_ENDPOINT
+
+cd maintenance-mode
+bundle install
+
+cf push -f manifest.yml
+start-maintenance whiteboard $CF_DOMAIN $WHITEBOARD_HOSTNAME

--- a/concourse/tasks/deploy-maintenance/deploy-maintenance.yml
+++ b/concourse/tasks/deploy-maintenance/deploy-maintenance.yml
@@ -8,6 +8,7 @@ image_resource:
 
 inputs:
   - name: whiteboard
+  - name: maintenance-mode
 
 run:
-  path: ./whiteboard/concourse/tasks/deploy/deploy.sh
+  path: ./whiteboard/concourse/tasks/deploy-maintenance/deploy-maintenance.sh

--- a/concourse/tasks/deploy/deploy.sh
+++ b/concourse/tasks/deploy/deploy.sh
@@ -1,37 +1,10 @@
 #!/bin/bash
 
-start-maintenance ()
-{
-    appName=$1
-    domain=$2
-    hostname=$3
-
-    cf map-route maintenance-mode ${domain} -n ${hostname}
-    cf unmap-route ${appName} ${domain} -n ${hostname}
-}
-
-stop-maintenance ()
-{
-    appName=$1
-    domain=$2
-    hostname=$3
-
-    cf map-route ${appName} ${domain} -n ${hostname}
-    cf unmap-route maintenance-mode ${domain} -n ${hostname}
-}
-
-
 wget -q -O cf-cli.deb https://cli.run.pivotal.io/stable?release=debian64
 sudo dpkg -i cf-cli.deb
 cf login -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE -a $CF_API_ENDPOINT
 
-cd maintenance-mode
-bundle install
-
-cf push -f manifest.yml
-start-maintenance whiteboard $CF_DOMAIN whiteboard-$ENVIRONMENT
-
-cd ../whiteboard
+cd whiteboard
 
 cf set-env whiteboard OKTA_SSO_TARGET_URL $OKTA_SSO_TARGET_URL
 cf set-env whiteboard OKTA_CERT_FINGERPRINT $OKTA_CERT_FINGERPRINT
@@ -51,12 +24,6 @@ if [ "$ENVIRONMENT" == "production" ]; then
 fi
 
 bundle install
-bundle exec rake SPACE=$CF_SPACE cf:deploy:$ENVIRONMENT
 
-STATUS=$?
-echo $STATUS
-if [ $STATUS -eq 0 ];then
-    stop-maintenance whiteboard $CF_DOMAIN whiteboard-$ENVIRONMENT
-else
-    exit $STATUS
-fi
+#takes hostname from config/cf-{ENVIRONMENT}.yml manifest
+bundle exec rake SPACE=$CF_SPACE cf:deploy:$ENVIRONMENT

--- a/concourse/tasks/map-routes/map-routes.sh
+++ b/concourse/tasks/map-routes/map-routes.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e -x
+
+wget -q -O cf-cli.deb https://cli.run.pivotal.io/stable?release=debian64
+sudo dpkg -i cf-cli.deb
+cf login -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE -a $CF_API_ENDPOINT
+
+cf unmap-route maintenance-mode $CF_DOMAIN -n $WHITEBOARD_HOSTNAME
+cf unmap-route whiteboard $CF_DOMAIN -n $TEMP_WHITEBOARD_HOSTNAME
+cf map-route whiteboard $CF_DOMAIN -n $WHITEBOARD_HOSTNAME
+

--- a/concourse/tasks/map-routes/map-routes.yml
+++ b/concourse/tasks/map-routes/map-routes.yml
@@ -10,4 +10,4 @@ inputs:
   - name: whiteboard
 
 run:
-  path: ./whiteboard/concourse/tasks/deploy/deploy.sh
+  path: ./whiteboard/concourse/tasks/map-routes/map-routes.sh

--- a/concourse/whiteboard-production-pipeline.yml
+++ b/concourse/whiteboard-production-pipeline.yml
@@ -10,6 +10,12 @@ resources:
     uri: git@github.com:pivotal/maintenance-mode.git
     private_key: {{maintenance-private-key}}
     branch: ruby-2.3.4
+- name: acceptance-tests
+  type: git
+  source:
+    uri: git@github.com:pivotal/whiteboard-acceptance-tests.git
+    private_key: {{maintenance-private-key}}
+    branch: master
 
 jobs:
   - name: build
@@ -17,13 +23,29 @@ jobs:
       - get: whiteboard
       - task: build
         file: whiteboard/concourse/tasks/build/build.yml
-  - name: deploy
+  - name: deploy-maintenance
     plan:
       - get: whiteboard
         trigger: true
         passed: [build]
       - get: maintenance-mode
-      - task: deploy
+      - task: deploy-maintenance
+        file: whiteboard/concourse/tasks/deploy-maintenance/deploy-maintenance.yml
+        params:
+          CF_USERNAME: {{cf-username}}
+          CF_PASSWORD: {{cf-password}}
+          CF_ORG: {{cf-org}}
+          CF_SPACE: whiteboard-production
+          CF_API_ENDPOINT: {{api-endpoint}}
+          ENVIRONMENT: production
+          CF_DOMAIN: {{cf-domain}}
+          WHITEBOARD_HOSTNAME: whiteboard
+  - name: deploy-whiteboard
+    plan:
+      - get: whiteboard
+        trigger: true
+        passed: [deploy-maintenance]
+      - task: deploy-whiteboard
         file: whiteboard/concourse/tasks/deploy/deploy.yml
         params:
           CF_USERNAME: {{cf-username}}
@@ -36,13 +58,30 @@ jobs:
           OKTA_SSO_TARGET_URL: {{okta-sso-target-url}}
           ENVIRONMENT: production
           SENTRY_DSN: {{sentry-dsn}}
+  - name: acceptance-tests
+    plan:
+      - get: whiteboard
+        passed: [deploy-whiteboard]
+        trigger: true
+      - get: acceptance-tests
+      - task: acceptance-tests
+        file: whiteboard/concourse/tasks/acceptance/acceptance.yml
+        params:
           CF_DOMAIN: {{cf-domain}}
-          EXCEPTIONAL_API_KEY: {{exceptional-api-key}}
-          GOOGLE_CLIENT_ID: {{google-client-id}}
-          GOOGLE_CLIENT_SECRET: {{google-client-secret}}
-          NEWRELIC_APP_NAME: {{newrelic-app-name}}
-          NEWRELIC_LICENSE: {{newrelic-license}}
-          WORDPRESS_BLOG_HOST: {{wordpress-blog-host}}
-          WORDPRESS_PASSWORD: {{wordpress-password}}
-          WORDPRESS_USER: {{wordpress-user}}
-          WORDPRESS_XMLRPC_ENDPOINT_PATH: {{wordpress-xmlrpc-endpoint-path}}
+          TEMP_WHITEBOARD_HOSTNAME: whiteboard-production-temp
+  - name: map-routes
+    plan:
+      - get: whiteboard
+        passed: [acceptance-tests]
+        trigger: true
+      - task: map-routes
+        file: whiteboard/concourse/tasks/map-routes/map-routes.yml
+        params:
+          CF_USERNAME: {{cf-username}}
+          CF_PASSWORD: {{cf-password}}
+          CF_ORG: {{cf-org}}
+          CF_SPACE: whiteboard-production
+          CF_API_ENDPOINT: {{api-endpoint}}
+          CF_DOMAIN: {{cf-domain}}
+          WHITEBOARD_HOSTNAME: whiteboard
+          TEMP_WHITEBOARD_HOSTNAME: whiteboard-production-temp

--- a/concourse/whiteboard-staging-pipeline.yml
+++ b/concourse/whiteboard-staging-pipeline.yml
@@ -10,6 +10,12 @@ resources:
     uri: git@github.com:pivotal/maintenance-mode.git
     private_key: {{maintenance-private-key}}
     branch: ruby-2.3.4
+- name: acceptance-tests
+  type: git
+  source:
+    uri: git@github.com:pivotal/whiteboard-acceptance-tests.git
+    private_key: {{maintenance-private-key}}
+    branch: master
 
 jobs:
   - name: build
@@ -17,13 +23,29 @@ jobs:
       - get: whiteboard
       - task: build
         file: whiteboard/concourse/tasks/build/build.yml
-  - name: deploy
+  - name: deploy-maintenance
     plan:
       - get: whiteboard
         trigger: true
         passed: [build]
       - get: maintenance-mode
-      - task: deploy
+      - task: deploy-maintenance
+        file: whiteboard/concourse/tasks/deploy-maintenance/deploy-maintenance.yml
+        params:
+          CF_USERNAME: {{cf-username}}
+          CF_PASSWORD: {{cf-password}}
+          CF_ORG: {{cf-org}}
+          CF_SPACE: whiteboard-staging
+          CF_API_ENDPOINT: {{api-endpoint}}
+          ENVIRONMENT: staging
+          CF_DOMAIN: {{cf-domain}}
+          WHITEBOARD_HOSTNAME: whiteboard-staging
+  - name: deploy-whiteboard
+    plan:
+      - get: whiteboard
+        trigger: true
+        passed: [deploy-maintenance]
+      - task: deploy-whiteboard
         file: whiteboard/concourse/tasks/deploy/deploy.yml
         params:
           CF_USERNAME: {{cf-username}}
@@ -37,3 +59,30 @@ jobs:
           ENVIRONMENT: staging
           SENTRY_DSN: {{sentry-dsn}}
           CF_DOMAIN: {{cf-domain}}
+  - name: acceptance-tests
+    plan:
+      - get: whiteboard
+        passed: [deploy-whiteboard]
+        trigger: true
+      - get: acceptance-tests
+      - task: acceptance-tests
+        file: whiteboard/concourse/tasks/acceptance/acceptance.yml
+        params:
+          CF_DOMAIN: {{cf-domain}}
+          TEMP_WHITEBOARD_HOSTNAME: whiteboard-staging-temp
+  - name: map-routes
+    plan:
+      - get: whiteboard
+        passed: [acceptance-tests]
+        trigger: true
+      - task: map-routes
+        file: whiteboard/concourse/tasks/map-routes/map-routes.yml
+        params:
+          CF_USERNAME: {{cf-username}}
+          CF_PASSWORD: {{cf-password}}
+          CF_ORG: {{cf-org}}
+          CF_SPACE: whiteboard-staging
+          CF_API_ENDPOINT: {{api-endpoint}}
+          CF_DOMAIN: {{cf-domain}}
+          WHITEBOARD_HOSTNAME: whiteboard-staging
+          TEMP_WHITEBOARD_HOSTNAME: whiteboard-staging-temp

--- a/config/cf-production.yml
+++ b/config/cf-production.yml
@@ -3,3 +3,4 @@ applications:
 - name: whiteboard
   command: bundle exec rake db:migrate && bundle exec unicorn -p $PORT -c ./config/unicorn.rb
   path: ../
+  host: whiteboard-production-temp

--- a/config/cf-staging.yml
+++ b/config/cf-staging.yml
@@ -3,4 +3,4 @@ applications:
 - name: whiteboard
   command: bundle exec rake db:migrate && bundle exec unicorn -p $PORT -c ./config/unicorn.rb
   path: ../
-  host: whiteboard-staging
+  host: whiteboard-staging-temp

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -27,7 +27,6 @@ if ENV['SMTP_RELAY'].present?
 elsif ENV['VCAP_SERVICES'].present?
 
   vcap_services = JSON.parse(ENV['VCAP_SERVICES'])
-  Rails.logger.info vcap_services.inspect
 
   if vcap_services.include? "sendgrid"
     # After starting your cloud foundry app run:


### PR DESCRIPTION
updated yml scripts to take in whiteboard as an input

made deploy-maintenance.sh executable

removed unneeded input from deploy-maintenance

removed unneeded input from deploy

fixed deploy.sh script

updated acceptance docker image and cf manifest and deploy.sh

updated acceptance.yml to use jdk instead of jre

added map-routes task

made map-routes executable

cleaned up pipeline scripts

updated acceptance.sh

updated pipelines to do a blue-green deployment and add acceptance tests

Signed-off-by: Drew Archibald <darchibald@pivotal.io>