### PR TITLE
Updated ruby version to account for latest patch version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.4'
+ruby '2.3.5'
 
 gem 'rails', '~> 4.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ DEPENDENCIES
   unicorn
 
 RUBY VERSION
-   ruby 2.3.4p301
+   ruby 2.3.5p376
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update
 RUN apt-get -y install wget
 
 # Install Ruby 2.3.*
-RUN apt-get -y install ruby2.3 ruby2.3-dev
+RUN echo "20171211" && apt-get -y install ruby2.3 ruby2.3-dev
 
 # Install misc dependencies
 RUN apt-get -y install build-essential patch zlib1g-dev liblzma-dev libxml2-dev libxslt1-dev libfontconfig1 libfreetype6 git curl unzip


### PR DESCRIPTION
Note that the Dockerfile change makes it easier to update containers when there is a change in the patch version, without waiting for concourse to blow up.